### PR TITLE
Enable Travis-CI for Pilot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "2.3"
+  - "2.4"
+  - "2.5"
+  - "2.6"
+  - "2.7"
+# command to install dependencies
+install: "pip install -r requirements.txt"
+# command to run tests
+script:
+  - export PYTHONPATH=${PWD%/*}
+  - ls $PYTHONPATH
+  - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 python:
-#  - "2.3"
-#  - "2.4"
-#  - "2.5"
   - "2.6"
   - "2.7"
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
 #  - "2.3"
 #  - "2.4"
 #  - "2.5"
-#  - "2.6"
+  - "2.6"
   - "2.7"
 # command to install dependencies
 install: "pip install -r requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "2.3"
-  - "2.4"
-  - "2.5"
-  - "2.6"
+#  - "2.3"
+#  - "2.4"
+#  - "2.5"
+#  - "2.6"
   - "2.7"
 # command to install dependencies
 install: "pip install -r requirements.txt"

--- a/Pilot/tests/Test_Pilot.py
+++ b/Pilot/tests/Test_Pilot.py
@@ -35,7 +35,7 @@ class CommandsTestCase( PilotTestCase ):
     self.pp.setup = 'TestSetup'
     self.pp.pilotCFGFileLocation = 'file://%s' % os.getcwd()
     gpv = GetPilotVersion( self.pp )
-    self.assertIsNone( gpv.execute() )
+    self.assertTrue( gpv.execute() is None )
     self.assertEqual( gpv.pp.releaseVersion, 'v1r1' )
 
 #############################################################################

--- a/PilotLogger/PilotLogger.py
+++ b/PilotLogger/PilotLogger.py
@@ -133,7 +133,7 @@ class PilotLogger( object ):
       self.fileWithUUID = config['fileWithID']
       self.networkCfg= [(config['host'], int(config['port']))]
       self.queuePath = config['queuePath']
-      self.sslCfg = { k: config[k] for k  in ('key_file', 'cert_file', 'ca_certs')}
+      self.sslCfg = dict((k, config[k]) for k  in ('key_file', 'cert_file', 'ca_certs'))
       return True
 
   def _isCorrectFlag( self, flag ):

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# Pilot
-DIRAC pilot. See diracgrid.org for more info

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 DIRAC - Pilots
 =============
 .. image:: https://travis-ci.org/DIRACGrid/Pilot.svg?branch=master
-    :target: https://travis-ci.org/DIRACGrid/DIRAC
+    :target: https://travis-ci.org/DIRACGrid/Pilot
 DIRAC (Distributed Infrastructure with Remote Agent Control) INTERWARE is a software framework for distributed computing providing a complete solution to one or more user community requiring access to distributed resources. DIRAC builds a layer between the users and the resources offering a common interface to a number of heterogeneous providers, integrating them in a seamless manner, providing interoperability, at the same time as an optimized, transparent and reliable usage of the resources.
 
 DIRAC has been started by the `LHCb collaboration <https://lhcb.web.cern.ch/lhcb/>`_ who still maintains it. It is now used by several communities (AKA VO=Virtual Organizations) for their distributed computing workflows.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 #Configuration file for py.test
 [pytest]
 python_files=Test_*.py
-addopts = -rx -v --color=yes --tb=long --ignore=tests --cov
+addopts = -rx -v --color=yes --tb=long --ignore=tests --cov=.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pylint
 pytest
 pytest-cov
 coverage
+stomp.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+mock
+pylint
+pytest
+pytest-cov
+coverage


### PR DESCRIPTION
Added the YML file for Travis, configured so that simultaneous 2.6 and 2.7 are tested. Sadly Travis only supports python >=2.6 otherwise we could also test older versions. 

Had to change PilotLogger since it used dict comprehension and adopt test to be compatible with 2.6