### PR TITLE
Discover pilot parameters (Commands, extensions and version) at runtime.

### DIFF
--- a/Pilot/dirac-pilot.py
+++ b/Pilot/dirac-pilot.py
@@ -41,10 +41,12 @@ if __name__ == "__main__":
   pilotParams.pilotScript = os.path.realpath( sys.argv[0] )
   pilotParams.pilotScriptName = os.path.basename( pilotParams.pilotScript )
   log.debug( 'PARAMETER [%s]' % ', '.join( map( str, pilotParams.optList ) ) )
+  pilotParams.retrievePilotParameters()
 
-  log.info( "Executing commands: %s" % str( pilotParams.commands ) )
   if pilotParams.commandExtensions:
     log.info( "Requested command extensions: %s" % str( pilotParams.commandExtensions ) )
+
+  log.info( "Executing commands: %s" % str( pilotParams.commands ) )
 
   for commandName in pilotParams.commands:
     command, module = getCommand( pilotParams, commandName, log )

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -33,6 +33,10 @@ __RCSID__ = "$Id$"
 class GetPilotVersion( CommandBase ):
   """ Used to get the pilot version that needs to be installed.
       If passed as a parameter, uses that one. If not passed, it looks for alternatives.
+      If the version is not passed as a parameter, it is taken from a json file that should look like:
+
+      { 'SetupName':{'Commands':{ Name of the grid': [list of commands]}, 'Extensions':['list of extensions'], 'Version':['xyz'],
+      'Defaults':{'Commands':{ 'defaultList': [list of commands]', 'Name of the grid': [list of commands]}, 'Version':['xyz']}}
 
       This assures that a version is always got even on non-standard Grid resources.
   """
@@ -59,7 +63,11 @@ class GetPilotVersion( CommandBase ):
       fp = open( self.pp.pilotCFGFile + '-local', 'r' )
       pilotCFGFileContent = json.load( fp )
       fp.close()
-      pilotVersions = [str( pv ) for pv in pilotCFGFileContent[self.pp.setup]['Version']]
+      # If the version of a specific setup is not present, we take the default version.
+      if self.pp.setup in pilotCFGFileContent and 'Version' in pilotCFGFileContent[self.pp.setup]:
+        pilotVersions = [str( pv ) for pv in pilotCFGFileContent[self.pp.setup]['Version']]
+      else:
+        pilotVersions = [str( pv ) for pv in pilotCFGFileContent['Defaults']['Version']]
       self.log.debug( "Pilot versions found: %s" % ', '.join( pilotVersions ) )
       self.log.info( "Setting pilot version to %s" % pilotVersions[0] )
       self.pp.releaseVersion = pilotVersions[0]

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -393,14 +393,15 @@ class CheckCECapabilities( CommandBase ):
                                                                         self.pp.queueName,
                                                                         " ".join( self.cfg ) )
     retCode, resourceDict = self.executeAndGetOutput( checkCmd, self.pp.installEnv )
+    if retCode:
+      self.log.error( "Could not get resource parameters [ERROR %d]" % retCode )
+      self.exitWithError( retCode )
     try:
       import json
       resourceDict = json.loads( resourceDict )
     except ValueError:
       self.log.error( "The pilot command output is not json compatible." )
       sys.exit( 1 )
-    if retCode:
-      self.log.warn( "Could not get resource parameters [ERROR %d]" % retCode )
     if resourceDict.get( 'Tag' ):
       self.pp.tags += resourceDict['Tag']
       self.cfg.append( '-FDMH' )
@@ -420,7 +421,8 @@ class CheckCECapabilities( CommandBase ):
       configureCmd = "%s %s" % ( self.pp.configureScript, " ".join( self.cfg ) )
       retCode, _configureOutData = self.executeAndGetOutput( configureCmd, self.pp.installEnv )
       if retCode:
-        self.log.warn( "Could not configure DIRAC [ERROR %d]" % retCode )
+        self.log.error( "Could not configure DIRAC [ERROR %d]" % retCode )
+        self.exitWithError( retCode )
 
 class CheckWNCapabilities( CommandBase ):
   """ Used to get capabilities specific to the Worker Node.
@@ -445,7 +447,8 @@ class CheckWNCapabilities( CommandBase ):
                                                                        " ".join( self.cfg ) )
     retCode, result = self.executeAndGetOutput( checkCmd, self.pp.installEnv )
     if retCode:
-      self.log.warn( "Could not get resource parameters [ERROR %d]" % retCode )
+      self.log.error( "Could not get resource parameters [ERROR %d]" % retCode )
+      self.exitWithError( retCode )
     try:
       result = result.split( ' ' )
       numberOfProcessor = int( result[0] )
@@ -476,7 +479,8 @@ class CheckWNCapabilities( CommandBase ):
       configureCmd = "%s %s" % ( self.pp.configureScript, " ".join( self.cfg ) )
       retCode, _configureOutData = self.executeAndGetOutput( configureCmd, self.pp.installEnv )
       if retCode:
-        self.log.warn( "Could not configure DIRAC [ERROR %d]" % retCode )
+        self.log.error( "Could not configure DIRAC [ERROR %d]" % retCode )
+        self.exitWithError( retCode )
 
 
 class ConfigureSite( CommandBase ):

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -403,7 +403,7 @@ class CheckCECapabilities( CommandBase ):
       self.log.error( "The pilot command output is not json compatible." )
       sys.exit( 1 )
     if resourceDict.get( 'Tag' ):
-      self.pp.tags.append( resourceDict['Tag'] )
+      self.pp.tags += resourceDict['Tag']
       self.cfg.append( '-FDMH' )
 
       if self.pp.useServerCertificate:
@@ -416,7 +416,7 @@ class CheckCECapabilities( CommandBase ):
       if self.debugFlag:
         self.cfg.append( '-ddd' )
 
-      self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( self.pp.tags ) )
+      self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( ( str( x ) for x in self.pp.tags ) ) )
 
       configureCmd = "%s %s" % ( self.pp.configureScript, " ".join( self.cfg ) )
       retCode, _configureOutData = self.executeAndGetOutput( configureCmd, self.pp.installEnv )

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -403,7 +403,7 @@ class CheckCECapabilities( CommandBase ):
       self.log.error( "The pilot command output is not json compatible." )
       sys.exit( 1 )
     if resourceDict.get( 'Tag' ):
-      self.pp.tags += resourceDict['Tag']
+      self.pp.tags.append( resourceDict['Tag'] )
       self.cfg.append( '-FDMH' )
 
       if self.pp.useServerCertificate:
@@ -416,7 +416,7 @@ class CheckCECapabilities( CommandBase ):
       if self.debugFlag:
         self.cfg.append( '-ddd' )
 
-      self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( ( str( x ) for x in self.pp.tags ) ) )
+      self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( self.pp.tags ) )
 
       configureCmd = "%s %s" % ( self.pp.configureScript, " ".join( self.cfg ) )
       retCode, _configureOutData = self.executeAndGetOutput( configureCmd, self.pp.installEnv )

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -367,6 +367,117 @@ class ConfigureBasics( CommandBase ):
       self.cfg.append( "-o /DIRAC/Security/CertFile=%s/hostcert.pem" % self.pp.certsLocation )
       self.cfg.append( "-o /DIRAC/Security/KeyFile=%s/hostkey.pem" % self.pp.certsLocation )
 
+class CheckCECapabilities( CommandBase ):
+  """ Used to get  CE tags.
+  """
+  def __init__( self, pilotParams ):
+    """ c'tor
+    """
+    super( CheckCECapabilities, self ).__init__( pilotParams )
+
+    # this variable contains the options that are passed to dirac-configure, and that will fill the local dirac.cfg file
+    self.cfg = []
+
+  def execute( self ):
+    """ Setup CE/Queue Tags
+    """
+
+    if self.pp.useServerCertificate:
+      self.cfg.append( '-o  /DIRAC/Security/UseServerCertificate=yes' )
+    if self.pp.localConfigFile:
+      self.cfg.append( self.pp.localConfigFile )  # this file is as input
+
+
+    checkCmd = 'dirac-resource-get-parameters -S %s -N %s -Q %s %s' % ( self.pp.site,
+                                                                        self.pp.ceName,
+                                                                        self.pp.queueName,
+                                                                        " ".join( self.cfg ) )
+    retCode, resourceDict = self.executeAndGetOutput( checkCmd, self.pp.installEnv )
+    try:
+      import json
+      resourceDict = json.loads( resourceDict )
+    except ValueError:
+      self.log.error( "The pilot command output is not json compatible." )
+      sys.exit( 1 )
+    if retCode:
+      self.log.warn( "Could not get resource parameters [ERROR %d]" % retCode )
+    if resourceDict.get( 'Tag' ):
+      self.pp.tags += resourceDict['Tag']
+      self.cfg.append( '-FDMH' )
+
+      if self.pp.useServerCertificate:
+        self.cfg.append( '-o  /DIRAC/Security/UseServerCertificate=yes' )
+
+      if self.pp.localConfigFile:
+        self.cfg.append( '-O %s' % self.pp.localConfigFile )  # this file is as output
+        self.cfg.append( self.pp.localConfigFile )  # this file is as input
+
+      if self.debugFlag:
+        self.cfg.append( '-ddd' )
+
+      self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( ( str( x ) for x in self.pp.tags ) ) )
+
+      configureCmd = "%s %s" % ( self.pp.configureScript, " ".join( self.cfg ) )
+      retCode, _configureOutData = self.executeAndGetOutput( configureCmd, self.pp.installEnv )
+      if retCode:
+        self.log.warn( "Could not configure DIRAC [ERROR %d]" % retCode )
+
+class CheckWNCapabilities( CommandBase ):
+  """ Used to get capabilities specific to the Worker Node.
+  """
+
+  def __init__( self, pilotParams ):
+    """ c'tor
+    """
+    super( CheckWNCapabilities, self ).__init__( pilotParams )
+    self.cfg = []
+
+  def execute( self ):
+    """ Discover #Processors and memory
+    """
+
+    if self.pp.useServerCertificate:
+      self.cfg.append( '-o /DIRAC/Security/UseServerCertificate=yes' )
+    if self.pp.localConfigFile:
+      self.cfg.append( self.pp.localConfigFile )  # this file is as input
+
+    checkCmd = 'dirac-wms-get-wn-parameters -S %s -N %s -Q %s %s' % ( self.pp.site, self.pp.ceName, self.pp.queueName,
+                                                                       " ".join( self.cfg ) )
+    retCode, result = self.executeAndGetOutput( checkCmd, self.pp.installEnv )
+    if retCode:
+      self.log.warn( "Could not get resource parameters [ERROR %d]" % retCode )
+    try:
+      result = result.split( ' ' )
+      numberOfProcessor = int( result[0] )
+      maxRAM = int( result[1] )
+    except ValueError:
+      self.log.error( "Wrong Command output %s" % result )
+      sys.exit( 1 )
+    if numberOfProcessor or maxRAM:
+      self.cfg.append( '-FDMH' )
+
+      if self.pp.useServerCertificate:
+        self.cfg.append( '-o /DIRAC/Security/UseServerCertificate=yes' )
+      if self.pp.localConfigFile:
+        self.cfg.append( '-O %s' % self.pp.localConfigFile )  # this file is as output
+        self.cfg.append( self.pp.localConfigFile )  # this file is as input
+
+      if self.debugFlag:
+        self.cfg.append( '-ddd' )
+
+      if numberOfProcessor:
+        self.cfg.append( '-o "/Resources/Computing/CEDefaults/NumberOfProcessors=%d"' % numberOfProcessor )
+      else:
+        self.log.warn( "Could not retrieve number of processors" )
+      if maxRAM:
+        self.cfg.append( '-o "/Resources/Computing/CEDefaults/MaxRAM=%d"' % maxRAM )
+      else:
+        self.log.warn( "Could not retrieve MaxRAM" )
+      configureCmd = "%s %s" % ( self.pp.configureScript, " ".join( self.cfg ) )
+      retCode, _configureOutData = self.executeAndGetOutput( configureCmd, self.pp.installEnv )
+      if retCode:
+        self.log.warn( "Could not configure DIRAC [ERROR %d]" % retCode )
+
 
 class ConfigureSite( CommandBase ):
   """ Command to configure DIRAC sites using the pilot options
@@ -681,9 +792,12 @@ class ConfigureCPURequirements( CommandBase ):
     self.log.info( "CPUTime left (in seconds) is %s" % cpuTime )
 
     # HS06s = seconds * HS06
-    self.pp.jobCPUReq = float( cpuTime ) * float( cpuNormalizationFactor )
-    self.log.info( "Queue length (which is also set as CPUTimeLeft) is %f" % self.pp.jobCPUReq )
-
+    try:
+      self.pp.jobCPUReq = float( cpuTime ) * float( cpuNormalizationFactor )
+      self.log.info( "Queue length (which is also set as CPUTimeLeft) is %f" % self.pp.jobCPUReq )
+    except ValueError:
+      self.log.error( 'Pilot command output does not have the correct format' )
+      sys.exit( 1 )
     # now setting this value in local file
     cfg = ['-FDMH']
     if self.pp.useServerCertificate:

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -564,9 +564,8 @@ class PilotParams( object ):
       if not result:
         self.log.info( "Could not download the json file, using the default commands list." )
       else:
-        fp = open( self.pilotCFGFile + '-local', 'r' )
-        pilotCFGFileContent = json.load( fp )
-        fp.close()
+        with open ( self.pilotCFGFile + '-local', 'r' ) as fp:
+          pilotCFGFileContent = json.load( fp )
         grid = self.site.split( '.' )[0]
         if self.setup in pilotCFGFileContent:
           if grid in pilotCFGFileContent[self.setup]['Commands']:

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -74,10 +74,8 @@ def retrieveUrlTimeout( url, fileName, log, timeout = 0 ):
       expectedBytes = 0
     data = remoteFD.read()
     if fileName:
-      if not os.path.exists( fileName + '-local' ):
-        localFD = open( fileName + '-local', "wb" )
+      with open( fileName + '-local', "wb" ) as localFD:
         localFD.write( data )
-        localFD.close()
     else:
       urlData += data
     remoteFD.close()

--- a/Pilot/tests/Test_Pilot.py
+++ b/Pilot/tests/Test_Pilot.py
@@ -30,13 +30,25 @@ class CommandsTestCase( PilotTestCase ):
 
     # Now defining a local file for test, and all the necessary parameters
     fp = open( 'pilot.json', 'w' )
-    json.dump( {'TestSetup':{'Version':['v1r1', 'v2r2']}}, fp )
+    json.dump( {'TestSetup':{'Commands':{'grid1':['x', 'y', 'z'], 'grid2':['d', 'f']}, 'Version':['v1r1', 'v2r2']}}, fp )
     fp.close()
     self.pp.setup = 'TestSetup'
     self.pp.pilotCFGFileLocation = 'file://%s' % os.getcwd()
     gpv = GetPilotVersion( self.pp )
     self.assertTrue( gpv.execute() is None )
     self.assertEqual( gpv.pp.releaseVersion, 'v1r1' )
+
+  def test_RetrievePilotParameters( self ):
+    fp = open( 'pilot.json', 'w' )
+    json.dump( {'TestSetup':{'Commands':{'grid1':['x', 'y', 'z'], 'grid2':['d', 'f']}, 'Extensions':['TestExtension'],
+                             'Version':['v1r1', 'v2r2']}}, fp )
+    fp.close()
+    self.pp.setup = 'TestSetup'
+    self.pp.site = 'grid1.cern.ch'
+    self.pp.pilotCFGFileLocation = 'file://%s' % os.getcwd()
+    self.pp.retrievePilotParameters()
+    self.assertEqual( self.pp.commands, ['x', 'y', 'z'] )
+    self.assertEqual( self.pp.commandExtensions, ['TestExtension'] )
 
 #############################################################################
 # Test Suite run

--- a/Pilot/tests/Test_Pilot.py
+++ b/Pilot/tests/Test_Pilot.py
@@ -39,10 +39,9 @@ class CommandsTestCase( PilotTestCase ):
     self.assertEqual( gpv.pp.releaseVersion, 'v1r1' )
 
   def test_RetrievePilotParameters( self ):
-    fp = open( 'pilot.json', 'w' )
-    json.dump( {'TestSetup':{'Commands':{'grid1':['x', 'y', 'z'], 'grid2':['d', 'f']}, 'Extensions':['TestExtension'],
+    with open ( 'pilot.json', 'w' ) as fp:
+      json.dump( {'TestSetup':{'Commands':{'grid1':['x', 'y', 'z'], 'grid2':['d', 'f']}, 'Extensions':['TestExtension'],
                              'Version':['v1r1', 'v2r2']}}, fp )
-    fp.close()
     self.pp.setup = 'TestSetup'
     self.pp.site = 'grid1.cern.ch'
     self.pp.pilotCFGFileLocation = 'file://%s' % os.getcwd()


### PR DESCRIPTION
Discover pilot parameters (Commands, extensions and version) at runtime.

Removed the -X and -E command line options.
The json file is not created if it already exists.

For issue #2724