### PR TITLE
Added configuration of landscape

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,0 +1,8 @@
+pylint:
+  disable:
+    - no-self-use
+
+pep8:
+  disable:
+    - E114
+    - E111


### PR DESCRIPTION
This is as in the pull request for DIRAC, with the addition of no-self-use. I don't know do you want to use the same .pylintrc as in DIRAC and add an additional flag to .landscape.yml or fix the .pylintrc for no-self-use

pep8:
E111 indentation is not a multiple of four
E114 indentation is not a multiple of four (comment)