### PR TITLE
[Discussion] dirac-pilot.py to use RESTDIRAC

### DIFF
--- a/Pilot/dirac-pilot.py
+++ b/Pilot/dirac-pilot.py
@@ -26,8 +26,7 @@ import sys
 import requests
 
 from types import ListType
-
-
+REST_URL = 'https://pclhcb192.cern.ch:9910'
 
 from pilotTools import Logger, pythonPathCheck, PilotParams, getCommand
 

--- a/Pilot/dirac-pilot.py
+++ b/Pilot/dirac-pilot.py
@@ -23,7 +23,11 @@ __RCSID__ = "$Id$"
 import os
 import getopt
 import sys
+import requests
+
 from types import ListType
+
+
 
 from pilotTools import Logger, pythonPathCheck, PilotParams, getCommand
 
@@ -41,14 +45,20 @@ if __name__ == "__main__":
   pilotParams.pilotScript = os.path.realpath( sys.argv[0] )
   pilotParams.pilotScriptName = os.path.basename( pilotParams.pilotScript )
   log.debug( 'PARAMETER [%s]' % ', '.join( map( str, pilotParams.optList ) ) )
-  pilotParams.retrievePilotParameters()
+
+  log.info( ' Getting commands from CS ' )
+  access_token = open( os.environ["OA_USER_TOKEN"], 'r' )
+  pilotCommands = requests.get( REST_URL + '/config/Value',
+                                params = {'access_token':access_token.read(),
+                                         'ValuePath':'/Operations/LHCb-Certification/Pilot/Commands/BOINC'}, verify = False )
+  log.info( "Executing commands: %s" % str( pilotCommands.text ) )
+
+  # pilotParams.retrievePilotParameters()
 
   if pilotParams.commandExtensions:
     log.info( "Requested command extensions: %s" % str( pilotParams.commandExtensions ) )
 
-  log.info( "Executing commands: %s" % str( pilotParams.commands ) )
-
-  for commandName in pilotParams.commands:
+  for commandName in pilotCommands:
     command, module = getCommand( pilotParams, commandName, log )
     if command is not None:
       log.info( "Command %s instantiated from %s" % ( commandName, module ) )


### PR DESCRIPTION
Getting list of commands from CS using the REST server. 

1) We need to have the REST SERVER URL available somewhere.
2) We need a token. It can be send by the SiteDirector for grid sites, we have to find a way for VMs. We can get the token using host certificate or we can have a public token with limited rights (only download public information from CS) 