### PR TITLE
Handle Commands/Extensions as proper lists or comma lists

### DIFF
--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -688,28 +688,46 @@ class PilotParams( object ):
         pass
 
     # Commands first
-    # FIXME: pilotSynchronizer() should publish these as comma-separated lists and we should split(',') them!!!
+    # FIXME: pilotSynchronizer() should publish these as comma-separated lists. We are ready for that.
     try:
-      self.commands = [str( pv ).strip() for pv in self.pilotJSON['Setups'][self.setup]['Commands'][self.gridCEType]]
+      if isinstance(self.pilotJSON['Setups'][self.setup]['Commands'][self.gridCEType], basestring):
+        self.commands = [str( pv ).strip() for pv in self.pilotJSON['Setups'][self.setup]['Commands'][self.gridCEType].split(',')]
+      else:
+        self.commands = [str( pv ).strip() for pv in self.pilotJSON['Setups'][self.setup]['Commands'][self.gridCEType]]
     except KeyError:
       try:
-        self.commands = [str( pv ).strip() for pv in self.pilotJSON['Setups'][self.setup]['Commands']['Defaults']]
+        if isinstance(self.pilotJSON['Setups'][self.setup]['Commands']['Defaults'], basestring):
+          self.commands = [str( pv ).strip() for pv in self.pilotJSON['Setups'][self.setup]['Commands']['Defaults'].split(',')]
+        else:
+          self.commands = [str( pv ).strip() for pv in self.pilotJSON['Setups'][self.setup]['Commands']['Defaults']]
       except KeyError:
         try:
-          self.commands = [str( pv ).strip() for pv in self.pilotJSON['Setups']['Defaults']['Commands'][self.gridCEType]]
+          if isinstance(self.pilotJSON['Setups']['Defaults']['Commands'][self.gridCEType], basestring):
+            self.commands = [str( pv ).strip() for pv in self.pilotJSON['Setups']['Defaults']['Commands'][self.gridCEType].split(',')]
+          else:
+            self.commands = [str( pv ).strip() for pv in self.pilotJSON['Setups']['Defaults']['Commands'][self.gridCEType]]
         except KeyError:
           try:
-            self.commands = [str( pv ).strip() for pv in self.pilotJSON['Defaults']['Commands']['Defaults']]
+            if isinstance(self.pilotJSON['Defaults']['Commands']['Defaults'], basestring):
+              self.commands = [str( pv ).strip() for pv in self.pilotJSON['Defaults']['Commands']['Defaults'].split(',')]
+            else:
+              self.commands = [str( pv ).strip() for pv in self.pilotJSON['Defaults']['Commands']['Defaults']]
           except KeyError:
             pass
 
     # Now the other options we handle
-    # FIXME: pilotSynchronizer() should publish this as a comma separated list and we should split(',') it!!!
+    # FIXME: pilotSynchronizer() should publish this as a comma separated list. We are ready for that.
     try:
-      self.commandExtensions = [str( pv ).strip() for pv in self.pilotJSON['Setups'][self.setup]['CommandExtensions']]
+      if isinstance(self.pilotJSON['Setups'][self.setup]['CommandExtensions'], basestring):       
+        self.commandExtensions = [str( pv ).strip() for pv in self.pilotJSON['Setups'][self.setup]['CommandExtensions'].split(',')]
+      else:
+        self.commandExtensions = [str( pv ).strip() for pv in self.pilotJSON['Setups'][self.setup]['CommandExtensions']]
     except KeyError:
       try:
-        self.commandExtensions = [str( pv ).strip() for pv in self.pilotJSON['Setups']['Defaults']['CommandExtensions']]
+        if isinstance(self.pilotJSON['Setups']['Defaults']['CommandExtensions'], basestring):
+          self.commandExtensions = [str( pv ).strip() for pv in self.pilotJSON['Setups']['Defaults']['CommandExtensions'].split(',')]
+        else:
+          self.commandExtensions = [str( pv ).strip() for pv in self.pilotJSON['Setups']['Defaults']['CommandExtensions']]        
       except KeyError:
         pass
 

--- a/Pilot/tests/Test_Pilot.py
+++ b/Pilot/tests/Test_Pilot.py
@@ -17,9 +17,9 @@ class PilotTestCase( unittest.TestCase ):
   def setUp( self ):
     # Define a local file for test, and all the necessary parameters
     with open ( 'pilot.json', 'w' ) as fp:
-      json.dump( {'Setups':{'TestSetup':{'Commands':{'cetype1':['x', 'y', 'z'],
+      json.dump( {'Setups':{'TestSetup':{'Commands':{'cetype1':['x,y, z'],
                                                      'cetype2':['d', 'f']},
-                                         'CommandExtensions':['TestExtension'],
+                                         'CommandExtensions':['TestExtension1,TestExtension2'],
                                          'NagiosProbes':'Nagios1,Nagios2',
                                          'NagiosPutURL':'https://127.0.0.2/',
                                          'Version':['v1r1','v2r2']}},
@@ -45,7 +45,7 @@ class CommandsTestCase( PilotTestCase ):
     """ Test the pilot.json parsing
     """
     self.assertEqual( self.pp.commands, ['x', 'y', 'z'] )
-    self.assertEqual( self.pp.commandExtensions, ['TestExtension'] )
+    self.assertEqual( self.pp.commandExtensions, ['TestExtension1','TestExtension2'] )
 
   def test_CheckWorkerNode ( self ):
     """ Test CheckWorkerNode command

--- a/Pilot/tests/Test_Pilot.py
+++ b/Pilot/tests/Test_Pilot.py
@@ -17,9 +17,9 @@ class PilotTestCase( unittest.TestCase ):
   def setUp( self ):
     # Define a local file for test, and all the necessary parameters
     with open ( 'pilot.json', 'w' ) as fp:
-      json.dump( {'Setups':{'TestSetup':{'Commands':{'cetype1':['x,y, z'],
+      json.dump( {'Setups':{'TestSetup':{'Commands':{'cetype1': 'x,y, z' ,
                                                      'cetype2':['d', 'f']},
-                                         'CommandExtensions':['TestExtension1,TestExtension2'],
+                                         'CommandExtensions':'TestExtension1,TestExtension2',
                                          'NagiosProbes':'Nagios1,Nagios2',
                                          'NagiosPutURL':'https://127.0.0.2/',
                                          'Version':['v1r1','v2r2']}},

--- a/Pilot/user_data
+++ b/Pilot/user_data
@@ -277,11 +277,12 @@ cp -f /scratch/plt/jobagent.*.log /scratch/plt/shutdown_message* /var/log/boot.l
   for i in *
   do
    if [ -f $i ] ; then 
-    curl --capath $X509_CERT_DIR --cert /root/hostkey.pem --cacert /root/hostkey.pem --location --upload-file "$i" "$JOBOUTPUTS/"
+    curl --capath $X509_CERT_DIR --cert /root/hostkey.pem --cacert /root/hostkey.pem --location --upload-file "$i" \
+     "$JOBOUTPUTS/"
 
     # This will be replaced by extended pilot logging??
     curl --capath $X509_CERT_DIR --cert /root/hostkey.pem --cacert /root/hostkey.pem --location --upload-file "$i" \
-      "https://lhcb-depo.cern.ch:9132/hosts/$CE_NAME/$HOSTNAME/$VM_UUID/"
+     "https://lhcb-depo.cern.ch:9132/hosts/##user_data_space##/##user_data_machinetype##/##user_data_machine_hostname##/##user_data_uuid##/"
    fi
   done
 )

--- a/Pilot/user_data
+++ b/Pilot/user_data
@@ -281,7 +281,7 @@ cp -f /scratch/plt/jobagent.*.log /scratch/plt/shutdown_message* /var/log/boot.l
 
     # This will be replaced by extended pilot logging??
     curl --capath $X509_CERT_DIR --cert /root/hostkey.pem --cacert /root/hostkey.pem --location --upload-file "$i" \
-      "https://lbvobox200.cern.ch:9132/hosts/$CE_NAME/$HOSTNAME/$VM_UUID/"
+      "https://lhcb-depo.cern.ch:9132/hosts/$CE_NAME/$HOSTNAME/$VM_UUID/"
    fi
   done
 )


### PR DESCRIPTION
This is to get ready for a corresponding change in the pilotSynchronizer to publish all multivalue options in pilot.json as comma-list strings rather some as proper lists, inconsistently. If other projects add pilot commands and corresponding multivalue options in the CS, then everything will then be consistent. It also avoids the need to hardcode multivalue->list processing in the pilotSynchronizer for some options (Commands and CommandExtensions).

There are also a couple of changes to the temporary LHCb code in the user_data file which uploads log files to lhcb-depo.cern.ch until we can use the extended pilot logging for production. 