### PR TITLE
Add test execution time to saved Nagios probe results

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -1192,7 +1192,7 @@ class NagiosProbes( CommandBase ):
                                                 key_file  = os.environ['X509_USER_PROXY'],
                                                 cert_file = os.environ['X509_USER_PROXY'] )
 
-          connection.request( 'PUT', path, str(retCode) + ' ' + int( time.time() ) + '\n' + output )
+          connection.request( 'PUT', path, str(retCode) + ' ' + str( int( time.time() ) ) + '\n' + output )
 
         except Exception as e:
           self.log.error( 'PUT of %s Nagios output fails with %s' % ( probeCmd, str(e) ) )

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -19,6 +19,7 @@
 
 import sys
 import os
+import time
 import stat
 import socket
 import httplib
@@ -1191,7 +1192,7 @@ class NagiosProbes( CommandBase ):
                                                 key_file  = os.environ['X509_USER_PROXY'],
                                                 cert_file = os.environ['X509_USER_PROXY'] )
 
-          connection.request( 'PUT', path, str(retCode) + '\n' + output )
+          connection.request( 'PUT', path, str(retCode) + ' ' + int( time.time() ) + '\n' + output )
 
         except Exception as e:
           self.log.error( 'PUT of %s Nagios output fails with %s' % ( probeCmd, str(e) ) )

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -718,7 +718,7 @@ class PilotParams( object ):
     # Now the other options we handle
     # FIXME: pilotSynchronizer() should publish this as a comma separated list. We are ready for that.
     try:
-      if isinstance(self.pilotJSON['Setups'][self.setup]['CommandExtensions'], basestring):       
+      if isinstance(self.pilotJSON['Setups'][self.setup]['CommandExtensions'], basestring):
         self.commandExtensions = [str( pv ).strip() for pv in self.pilotJSON['Setups'][self.setup]['CommandExtensions'].split(',')]
       else:
         self.commandExtensions = [str( pv ).strip() for pv in self.pilotJSON['Setups'][self.setup]['CommandExtensions']]

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -727,7 +727,7 @@ class PilotParams( object ):
         if isinstance(self.pilotJSON['Setups']['Defaults']['CommandExtensions'], basestring):
           self.commandExtensions = [str( pv ).strip() for pv in self.pilotJSON['Setups']['Defaults']['CommandExtensions'].split(',')]
         else:
-          self.commandExtensions = [str( pv ).strip() for pv in self.pilotJSON['Setups']['Defaults']['CommandExtensions']]        
+          self.commandExtensions = [str( pv ).strip() for pv in self.pilotJSON['Setups']['Defaults']['CommandExtensions']]
       except KeyError:
         pass
 


### PR DESCRIPTION
The one-line change to pilotCommands.py puts the time the Nagios probe was run in the saved results file itself. 

This is needed by check_pilot_results in LHCbSAM, which needs to know the time so it can flag stale results as "unknown".  This mechanism allows the test result files to be migrated or mirrored from one HTTPS server to another without needing to update the file datestamps reported by HTTP Last-Modified header.