### PR TITLE
Tags in Pilot3

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -385,7 +385,8 @@ class CheckCECapabilities( CommandBase ):
       if self.debugFlag:
         self.cfg.append( '-ddd' )
 
-      self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( ( str( x ) for x in self.pp.tags ) ) )
+      tags = ','.join( ( str( x ) for x in self.pp.tags ) ) 
+      self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s" -o "/AgentJobRequirements/RequiredTag=%s"' % ( tags, tags ) )
 
       configureCmd = "%s %s" % ( self.pp.configureScript, " ".join( self.cfg ) )
       retCode, _configureOutData = self.executeAndGetOutput( configureCmd, self.pp.installEnv )

--- a/Pilot/user_data_vm
+++ b/Pilot/user_data_vm
@@ -307,7 +307,7 @@ else
 fi
 
 if [ '##user_data_option_dirac_tag##' != '' ] ; then
-  TAGS="-o '/Resources/Computing/CEDefaults/Tag=##user_data_option_dirac_tag##'"
+  TAGS='-o /Resources/Computing/CEDefaults/Tag=##user_data_option_dirac_tag##'
 fi
 
 # Now run the pilot script

--- a/Pilot/user_data_vm
+++ b/Pilot/user_data_vm
@@ -307,7 +307,7 @@ else
 fi
 
 if [ '##user_data_option_dirac_tag##' != '' ] ; then
-  TAGS='-o /Resources/Computing/CEDefaults/Tag=##user_data_option_dirac_tag##'
+  TAGS='-o /Resources/Computing/CEDefaults/Tag=##user_data_option_dirac_tag## -o /AgentJobRequirements/RequiredTag=##user_data_option_dirac_tag##'
 fi
 
 # Now run the pilot script


### PR DESCRIPTION
This patch adds 

- an option to locally define tags when customising the user_data file, which is useful for testing and for features the site knows about at the host level (e.g. GPUs). 

- RequiredTag= is added back in alongside Tag=. This was lost when this functionality was moved from the SiteDirector to the pilotCommands.py in DIRAC (added in PR #2823 and (re)moved in PR #3348)

This functionality has been verified to work in VMs: payloads with Tags=xxxx match and run; payloads without Tags=xxxx are not run.