### PR TITLE
Changes to user_data_** and replace UnpackDev with ReplaceDIRACCode

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -288,8 +288,10 @@ class ReplaceDIRACCode( CommandBase ):
 
     # Add the ReplacementCode directory to the Python path
     self.pp.installEnv['PYTHONPATH'] = os.getcwd() + os.path.sep + 'ReplacementCode' + ':' + self.pp.installEnv['PYTHONPATH']
+    self.pp.installEnv['PATH'] = os.getcwd() + os.path.sep + 'ReplacementCode' + os.path.sep + 'scripts:' + self.pp.installEnv['PATH']
 
-    self.log.info( "TGZ file %s unpacked. PYTHONPATH updated to be %s" % ( self.pp.replaceDIRACCode, self.pp.installEnv['PYTHONPATH'] ) )
+    self.log.info( "TGZ file %s unpacked. PYTHONPATH updated to be %s and PATH updated to be %s" % 
+                         ( self.pp.replaceDIRACCode, self.pp.installEnv['PYTHONPATH'], self.pp.installEnv['PATH'] ) )
 
 class ConfigureBasics( CommandBase ):
   """ This command completes DIRAC installation.

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -598,11 +598,12 @@ class ConfigureSite( CommandBase ):
   def __setFlavour( self ):
 
     pilotRef = 'Unknown'
+    self.pp.flavour = 'Generic'
 
-    # Pilot reference is specified at submission
+    # If pilot reference is specified at submission, then set flavour to DIRAC
+    # unless overridden by presence of batch system environment variables
     if self.pp.pilotReference:
       self.pp.flavour = 'DIRAC'
-      pilotRef = self.pp.pilotReference
 
     # Take the reference from the Torque batch system
     if 'PBS_JOBID' in os.environ:
@@ -620,7 +621,6 @@ class ConfigureSite( CommandBase ):
       pilotRef = 'sshge://' + self.pp.ceName + '/' + os.environ['JOB_ID']
     # Generic JOB_ID
     elif 'JOB_ID' in os.environ:
-      self.pp.flavour = 'Generic'
       pilotRef = 'generic://' + self.pp.ceName + '/' + os.environ['JOB_ID']
 
     # Condor
@@ -696,6 +696,14 @@ class ConfigureSite( CommandBase ):
         self.boincHostPlatform = os.environ['BOINC_HOST_PLATFORM']
       if 'BOINC_HOST_NAME' in os.environ:
         self.boincHostName = os.environ['BOINC_HOST_NAME']
+
+    # Pilot reference is given explicitly in environment
+    if 'PILOT_UUID' in os.environ:
+      pilotRef = os.environ['PILOT_UUID']
+
+    # Pilot reference is specified at submission
+    if self.pp.pilotReference:
+      pilotRef = self.pp.pilotReference
 
     self.log.debug( "Flavour: %s; pilot reference: %s " % ( self.pp.flavour, pilotRef ) )
 

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -1286,35 +1286,3 @@ class NagiosProbes( CommandBase ):
     self._setNagiosOptions()
     self._runNagiosProbes()
 
-class UnpackDev( CommandBase ):
-  """ REPLACED by ReplaceDIRACCode !!!!
-      Unpack dev.tgz from the pilot directory into the pilot directory
-      Put dev.tgz in the remote pilot directory to have it fetched along
-      with the rest of the pilot scripts. The UnpackDev pilot command
-      needs to be listed after InstallDIRAC if it contains dev versions
-      of DIRAC modules.
-  """
-
-  def __init__( self, pilotParams ):
-    """ c'tor
-    """
-    super( UnpackDev, self ).__init__( pilotParams )
-    self.devFile = 'dev.tgz'
-
-  def execute( self ):
-    """ Standard entry point to a pilot command
-    """
-    self.log.info( 'Unpacking ' + self.devFile )
-    try:
-      tar = tarfile.open( self.devFile )
-    except Exception as e:
-      raise Exception( "Could not open %s (%s)" % ( self.devFile, str( e ) ) )
-
-    try:
-      tar.extractall()
-    except Exception as e:
-      raise Exception( "Could not unpack %s (%s)" % ( self.devFile, str( e ) ) )
-    finally:
-      tar.close()
-
-    self.log.info( "%s unpacked successfully" % self.devFile )

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -479,6 +479,7 @@ class PilotParams( object ):
     self.architectureScript = 'dirac-platform'
     self.certsLocation = '%s/etc/grid-security' % self.workingDir
     self.pilotCFGFile = 'pilot.json'
+    self.replaceDIRACCode = ''
     self.pilotLogging = False
 
     # Set number of allocatable processors from MJF if available
@@ -488,43 +489,44 @@ class PilotParams( object ):
       self.processors = 1
 
     # Pilot command options
-    self.cmdOpts = ( ( 'b', 'build', 'Force local compilation' ),
-                     ( 'd', 'debug', 'Set debug flag' ),
+    self.cmdOpts = ( ( 'a:', 'gridCEType=', 'Grid CE Type (CREAM etc)' ),
+                     ( 'b',  'build', 'Force local compilation' ),
+                     ( 'c',  'cert', 'Use server certificate instead of proxy' ),
+                     ( 'd',  'debug', 'Set debug flag' ),
                      ( 'e:', 'extraPackages=', 'Extra packages to install (comma separated)' ),
-                     ( 'E:', 'commandExtensions=', 'Python modules with extra commands' ),
-                     ( 'X:', 'commands=', 'Pilot commands to execute' ),
-                     ( 'Z:', 'commandOptions=', 'Options parsed by command modules' ),
                      ( 'g:', 'grid=', 'lcg tools package version' ),
-                     ( 'h', 'help', 'Show this help' ),
+                     ( 'h',  'help', 'Show this help' ),
                      ( 'i:', 'python=', 'Use python<26|27> interpreter' ),
-                     ( 'k', 'keepPP', 'Do not clear PYTHONPATH on start' ),
+                     ( 'k',  'keepPP', 'Do not clear PYTHONPATH on start' ),
                      ( 'l:', 'project=', 'Project to install' ),
-                     ( 'p:', 'platform=', 'Use <platform> instead of local one' ),
-                     ( 'u:', 'url=', 'Use <url> to download tarballs' ),
-                     ( 'r:', 'release=', 'DIRAC release to install' ),
                      ( 'n:', 'name=', 'Set <Site> as Site Name' ),
+                     ( 'o:', 'option=', 'Option=value to add' ),
+                     ( 'p:', 'platform=', 'Use <platform> instead of local one' ),
+                     ( 'r:', 'release=', 'DIRAC release to install' ),
+                     ( 's:', 'section=', 'Set base section for relative parsed options' ),
+                     ( 'u:', 'url=', 'Use <url> to download tarballs' ),
+                     ( 'x:', 'execute=', 'Execute instead of JobAgent' ),
+                     ( 'y:', 'CEType=', 'CE Type (normally InProcess)' ),
+                     ( 'z',  'pilotLogging', 'Activate pilot logging system' ),
+                     ( 'C:', 'configurationServer=', 'Configuration servers to use' ), # FIXME: -C is used twice! Which one to keep?
+                     ( 'C:', 'certLocation=', 'Specify server certificate location' ), # FIXME: -C is used twice! Which one to keep?
+                     ( 'G:', 'Group=', 'DIRAC Group to use' ),
                      ( 'D:', 'disk=', 'Require at least <space> MB available' ),
+                     ( 'E:', 'commandExtensions=', 'Python modules with extra commands' ),
+                     ( 'F:', 'pilotCFGFile=', 'Specify pilot CFG file' ),
                      ( 'M:', 'MaxCycles=', 'Maximum Number of JobAgent cycles to run' ),
                      ( 'N:', 'Name=', 'CE Name' ),
+                     ( 'O:', 'OwnerDN=', 'Pilot OwnerDN (for private pilots)' ),
                      ( 'Q:', 'Queue=', 'Queue name' ),
-                     ( 'y:', 'CEType=', 'CE Type (normally InProcess)' ),
-                     ( 'a:', 'gridCEType=', 'Grid CE Type (CREAM etc)' ),
+                     ( 'R:', 'reference=', 'Use this pilot reference' ),
                      ( 'S:', 'setup=', 'DIRAC Setup to use' ),
-                     ( 'C:', 'configurationServer=', 'Configuration servers to use' ),
-                     ( 'T:', 'CPUTime', 'Requested CPU Time' ),
-                     ( 'G:', 'Group=', 'DIRAC Group to use' ),
-                     ( 'O:', 'OwnerDN', 'Pilot OwnerDN (for private pilots)' ),
+                     ( 'T:', 'CPUTime=', 'Requested CPU Time' ),
                      ( 'U',  'Upload', 'Upload compiled distribution (if built)' ),
                      ( 'V:', 'installation=', 'Installation configuration file' ),
                      ( 'W:', 'gateway=', 'Configure <gateway> as DIRAC Gateway during installation' ),
-                     ( 's:', 'section=', 'Set base section for relative parsed options' ),
-                     ( 'o:', 'option=', 'Option=value to add' ),
-                     ( 'c', 'cert', 'Use server certificate instead of proxy' ),
-                     ( 'C:', 'certLocation=', 'Specify server certificate location' ),
-                     ( 'F:', 'pilotCFGFile=', 'Specify pilot CFG file' ),
-                     ( 'R:', 'reference=', 'Use this pilot reference' ),
-                     ( 'x:', 'execute=', 'Execute instead of JobAgent' ),
-                     ( 'z:', 'pilotLogging', 'Activate pilot logging system' ),
+                     ( 'X:', 'commands=', 'Pilot commands to execute' ),
+                     ( 'Y:', 'replaceDIRACCode=', 'URL of replacement DIRAC TGZ archive' ),
+                     ( 'Z:', 'commandOptions=', 'Options parsed by command modules' )
                    )
 
     # Possibly get Setup and JSON URL/filename from command line
@@ -569,7 +571,7 @@ class PilotParams( object ):
         self.commands = v.split( ',' )
       elif o == '-Z' or o == '--commandOptions':
         for i in v.split( ',' ):
-          self.commandOptions[i.split( '=' )[0]] = i.split( '=', 1 )[1]
+          self.commandOptions[ i.split( '=', 1 )[0] ] = i.split( '=', 1 )[1]
       elif o == '-e' or o == '--extraPackages':
         self.extensions = v.split( ',' )
       elif o == '-n' or o == '--name':
@@ -621,6 +623,8 @@ class PilotParams( object ):
           self.procesors = int(v)
         except:
           pass
+      elif o == '-Y' or o == '--replaceDIRACCode':
+        self.replaceDIRACCode = v
       elif o == '-z' or o == '--pilotLogging':
         self.pilotLogging = True
       elif o in ( '-o', '--option' ):
@@ -784,72 +788,3 @@ class PilotParams( object ):
         self.releaseProject = str( self.pilotJSON['Setups']['Defaults']['Project'] )
       except KeyError:
         pass
-
-  def __initCommandLine2( self ):
-    """ Parses and interpret options on the command line: second pass (most authoritative)
-    """
-
-    self.optList, __args__ = getopt.getopt( sys.argv[1:],
-                                            "".join( [ opt[0] for opt in self.cmdOpts ] ),
-                                            [ opt[1] for opt in self.cmdOpts ] )
-    for o, v in self.optList:
-      if o == '-E' or o == '--commandExtensions':
-        self.commandExtensions = v.split( ',' )
-      elif o == '-X' or o == '--commands':
-        self.commands = v.split( ',' )
-      elif o == '-Z' or o == '--commandOptions':
-        for opts in v.split(','):
-          self.commandOptions[opts.split('=',1)[0].strip()] = opts.split('=',1)[1].strip()
-      elif o == '-e' or o == '--extraPackages':
-        self.extensions = v.split( ',' )
-      elif o == '-n' or o == '--name':
-        self.site = v
-      elif o == '-y' or o == '--CEType':
-        self.ceType = v
-      elif o == '-Q' or o == '--Queue':
-        self.queueName = v
-      elif o == '-R' or o == '--reference':
-        self.pilotReference = v
-      elif o in ( '-C', '--configurationServer' ):
-        self.configServer = v
-      elif o in ( '-G', '--Group' ):
-        self.userGroup = v
-      elif o in ( '-x', '--execute' ):
-        self.executeCmd = v
-      elif o in ( '-O', '--OwnerDN' ):
-        self.userDN = v
-      elif o in ( '-V', '--installation' ):
-        self.installation = v
-      elif o == '-p' or o == '--platform':
-        self.platform = v
-      elif o == '-D' or o == '--disk':
-        try:
-          self.minDiskSpace = int( v )
-        except ValueError:
-          pass
-      elif o == '-r' or o == '--release':
-        self.releaseVersion = v.split(',',1)[0]
-      elif o in ( '-l', '--project' ):
-        self.releaseProject = v
-      elif o in ( '-W', '--gateway' ):
-        self.gateway = v
-      elif o == '-c' or o == '--cert':
-        self.useServerCertificate = True
-      elif o == '-C' or o == '--certLocation':
-        self.certsLocation = v
-      elif o == '-M' or o == '--MaxCycles':
-        try:
-          self.maxCycles = min( self.MAX_CYCLES, int( v ) )
-        except ValueError:
-          pass
-      elif o in ( '-T', '--CPUTime' ):
-        self.jobCPUReq = v
-      elif o == '-P' or o == '--processors':
-        try:
-          self.procesors = int(v)
-        except:
-          pass
-      elif o == '-z' or o == '--pilotLogging':
-        self.pilotLogging = True
-      elif o in ( '-o', '--option' ):
-        self.genericOption = v

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -571,7 +571,7 @@ class PilotParams( object ):
         self.commands = v.split( ',' )
       elif o == '-Z' or o == '--commandOptions':
         for i in v.split( ',' ):
-          self.commandOptions[ i.split( '=', 1 )[0] ] = i.split( '=', 1 )[1]
+          self.commandOptions[ i.split( '=', 1 )[0].strip() ] = i.split( '=', 1 )[1].strip()
       elif o == '-e' or o == '--extraPackages':
         self.extensions = v.split( ',' )
       elif o == '-n' or o == '--name':

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -508,12 +508,12 @@ class PilotParams( object ):
                      ( 'x:', 'execute=', 'Execute instead of JobAgent' ),
                      ( 'y:', 'CEType=', 'CE Type (normally InProcess)' ),
                      ( 'z',  'pilotLogging', 'Activate pilot logging system' ),
-                     ( 'C:', 'configurationServer=', 'Configuration servers to use' ), # FIXME: -C is used twice! Which one to keep?
+                     ( 'C:', 'configurationServer=', 'Configuration servers to use' ),
                      ( 'D:', 'disk=', 'Require at least <space> MB available' ),
                      ( 'E:', 'commandExtensions=', 'Python modules with extra commands' ),
                      ( 'F:', 'pilotCFGFile=', 'Specify pilot CFG file' ),
                      ( 'G:', 'Group=', 'DIRAC Group to use' ),
-                     ( 'K:', 'certLocation=', 'Specify server certificate location' ), # FIXME: -C is used twice! Which one to keep?
+                     ( 'K:', 'certLocation=', 'Specify server certificate location' ),
                      ( 'M:', 'MaxCycles=', 'Maximum Number of JobAgent cycles to run' ),
                      ( 'N:', 'Name=', 'CE Name' ),
                      ( 'O:', 'OwnerDN=', 'Pilot OwnerDN (for private pilots)' ),

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -509,11 +509,11 @@ class PilotParams( object ):
                      ( 'y:', 'CEType=', 'CE Type (normally InProcess)' ),
                      ( 'z',  'pilotLogging', 'Activate pilot logging system' ),
                      ( 'C:', 'configurationServer=', 'Configuration servers to use' ), # FIXME: -C is used twice! Which one to keep?
-                     ( 'C:', 'certLocation=', 'Specify server certificate location' ), # FIXME: -C is used twice! Which one to keep?
-                     ( 'G:', 'Group=', 'DIRAC Group to use' ),
                      ( 'D:', 'disk=', 'Require at least <space> MB available' ),
                      ( 'E:', 'commandExtensions=', 'Python modules with extra commands' ),
                      ( 'F:', 'pilotCFGFile=', 'Specify pilot CFG file' ),
+                     ( 'G:', 'Group=', 'DIRAC Group to use' ),
+                     ( 'K:', 'certLocation=', 'Specify server certificate location' ), # FIXME: -C is used twice! Which one to keep?
                      ( 'M:', 'MaxCycles=', 'Maximum Number of JobAgent cycles to run' ),
                      ( 'N:', 'Name=', 'CE Name' ),
                      ( 'O:', 'OwnerDN=', 'Pilot OwnerDN (for private pilots)' ),

--- a/Pilot/tests/Test_Pilot.py
+++ b/Pilot/tests/Test_Pilot.py
@@ -118,6 +118,8 @@ class CommandsTestCase( PilotTestCase ):
     # Fails if tar zxvf command fails
     pp = PilotParams()
     pp.replaceDIRACCode = 'testing.tgz'
+    pp.installEnv['PYTHONPATH'] = '/some/where'
+    pp.installEnv['PATH'] = '/some/where/else'
     up = ReplaceDIRACCode( pp )
     res = up.execute()
     self.assertEqual(res, None)

--- a/Pilot/tests/Test_Pilot.py
+++ b/Pilot/tests/Test_Pilot.py
@@ -11,7 +11,7 @@ import sys
 import os
 
 from Pilot.pilotTools import PilotParams
-from Pilot.pilotCommands import CheckWorkerNode, ConfigureSite, NagiosProbes, UnpackDev
+from Pilot.pilotCommands import CheckWorkerNode, ConfigureSite, NagiosProbes
 
 class PilotTestCase( unittest.TestCase ):
   """ Base class for the Agents test cases
@@ -108,18 +108,6 @@ class CommandsTestCase( PilotTestCase ):
 
     self.assertEqual( nagios.nagiosProbes, ['Nagios1', 'Nagios2'] )
     self.assertEqual( nagios.nagiosPutURL, 'https://127.0.0.2/' )
-
-  def test_UnpackDev ( self ):
-    """ Test UnpackDev command
-    """
-    # Set up the dev.tgz file
-    os.system( 'echo 123 > 123.txt ; tar zcvf dev.tgz 123.txt ; rm -f 123.txt ' )
-
-    # Fails if tar zxvf command fails
-    pp = PilotParams()
-    up = UnpackDev( pp )
-    res = up.execute()
-    self.assertEqual(res, None)
 
 #############################################################################
 # Test Suite run

--- a/Pilot/tests/Test_Pilot.py
+++ b/Pilot/tests/Test_Pilot.py
@@ -11,7 +11,7 @@ import sys
 import os
 
 from Pilot.pilotTools import PilotParams
-from Pilot.pilotCommands import CheckWorkerNode, ConfigureSite, NagiosProbes
+from Pilot.pilotCommands import CheckWorkerNode, ConfigureSite, NagiosProbes, ReplaceDIRACCode
 
 class PilotTestCase( unittest.TestCase ):
   """ Base class for the Agents test cases
@@ -108,6 +108,19 @@ class CommandsTestCase( PilotTestCase ):
 
     self.assertEqual( nagios.nagiosProbes, ['Nagios1', 'Nagios2'] )
     self.assertEqual( nagios.nagiosPutURL, 'https://127.0.0.2/' )
+
+  def test_ReplaceDIRACCode ( self ):
+    """ Test UnpackDev command
+    """
+    # Set up the dev.tgz file
+    os.system( 'echo 123 > 123.txt ; tar zcvf testing.tgz 123.txt ; rm -f 123.txt ' )
+
+    # Fails if tar zxvf command fails
+    pp = PilotParams()
+    pp.replaceDIRACCode = 'testing.tgz'
+    up = ReplaceDIRACCode( pp )
+    res = up.execute()
+    self.assertEqual(res, None)
 
 #############################################################################
 # Test Suite run

--- a/Pilot/user_data_sc
+++ b/Pilot/user_data_sc
@@ -1,0 +1,116 @@
+#!/bin/sh
+
+(
+date --utc +"%Y-%m-%d %H:%M:%S %Z user_data_sc Start user_data_sc on `hostname`"
+
+cd $HOME
+
+# Record MJFJO if substituted here by VM lifecycle manager
+export MACHINEFEATURES='##user_data_machinefeatures_url##'
+export JOBFEATURES='##user_data_jobfeatures_url##'
+export JOBOUTPUTS='##user_data_joboutputs_url##'
+
+export CE_NAME='##user_data_space##'
+export VM_UUID='##user_data_uuid##'
+
+if [ "$VM_UUID" = "" -a "$JOBFEATURES" != "" ] ; then
+  export VM_UUID=`cat $JOBFEATURES/job_id`
+fi
+
+if [ "$VM_UUID" = "" ] ; then
+  # If still unset then just use the hostname from the VM lifecycle manager
+  export VM_UUID=`date +'%s.##user_data_vm_hostname##'`
+fi
+
+export JOB_ID="##user_data_space##:$VM_UUID:##user_data_machinetype##"
+
+mkdir -p $HOME/grid-security
+export X509_USER_PROXY=$HOME/grid-security/x509proxy.pem
+
+if [ ! -z "##user_data_option_x509_proxy##" ] ; then
+  # Simple if we are given an X.509 Proxy
+  cat <<X5_EOF > $X509_USER_PROXY
+##user_data_option_x509_proxy##
+X5_EOF
+
+  cp $X509_USER_PROXY $HOME/grid-security/hostkey.pem
+  cp $X509_USER_PROXY $HOME/grid-security/hostcert.pem
+
+elif [ ! -z "##user_data_option_hostkey##" -a ! -z "##user_data_option_hostcert##" ] ; then
+  # Given full host cert/key pair
+
+  cat <<X5_EOF > $HOME/grid-security/hostkey.pem
+##user_data_option_hostkey##
+X5_EOF
+
+  cat <<X5_EOF > $HOME/grid-security/hostcert.pem
+##user_data_option_hostcert##
+X5_EOF
+
+  cat $HOME/grid-security/hostkey.pem $HOME/grid-security/hostcert.pem > $X509_USER_PROXY
+else
+  date --utc +"%Y-%m-%d %H:%M:%S %Z Neither user_data_option_x509_proxy or user_data_option_hostkey/_hostcert defined!"
+fi
+
+chmod 0400 $HOME/grid-security/*.pem
+
+# Get CA certs from cvmfs
+ln -sf /cvmfs/grid.cern.ch/etc/grid-security/ $HOME/grid-security/
+export X509_CERT_DIR=$HOME/grid-security/certificates
+
+. /cvmfs/grid.cern.ch/emi3wn-latest/etc/profile.d/a1_grid_env.sh
+. /cvmfs/grid.cern.ch/emi3wn-latest/etc/profile.d/setup-wn-example.sh
+
+# Log HTTP proxies used for cvmfs
+attr -g proxy /mnt/.ro
+for i in /cvmfs/*
+do
+  attr -g proxy $i
+done
+
+# Fetch the DIRAC pilot scripts
+if [ '##user_data_option_dirac_pilot_url##' != '' ] ; then
+  wget --no-directories --recursive --no-parent --execute robots=off --reject 'index.html*' --ca-directory=$X509_CERT_DIR '##user_data_option_dirac_pilot_url##'
+elif [ '##user_data_url##' != '' ] ; then
+  # Remove user_data file name back to final slash
+  user_data_dir=`echo '##user_data_url##' | sed 's:[^/]*$::'`
+  wget --no-directories --recursive --no-parent --execute robots=off --reject 'index.html*' --ca-directory=$X509_CERT_DIR "$user_data_dir"
+else
+  wget --no-directories --recursive --no-parent --execute robots=off --reject 'index.html*' --ca-directory=$X509_CERT_DIR https://lhcb-portal-dirac.cern.ch/pilot/
+fi    
+
+if [ '##user_data_option_dirac_queue##' != '' ] ; then
+  QUEUE='##user_data_option_dirac_queue##'
+else
+  QUEUE=default
+fi
+
+# Now run the pilot script
+python $HOME/dirac-pilot.py \
+ --debug \
+ -o '/LocalSite/SubmitPool=Test' \
+ --Name '##user_data_space##' \
+ --Queue $QUEUE \
+ --MaxCycles 1 \
+ --cert --certLocation $HOME/grid-security \
+ ##user_data_option_dirac_opts## \
+  >##user_data_joboutputs_url##/dirac-pilot.log 2>&1
+
+# Save JobAgent and System logs
+cp -f $HOME/jobagent.*.log $HOME/shutdown_message* ##user_data_joboutputs_url##
+
+(
+  cd ##user_data_joboutputs_url##
+  for i in *
+  do
+   if [ -f $i ] ; then 
+    # This will be replaced by extended pilot logging??
+    curl --capath $X509_CERT_DIR --cert $HOME/grid-security/x509proxy.pem --cacert $HOME/grid-security/x509proxy.pem --location --upload-file "$i" \
+     "https://lhcb-depo.cern.ch:9132/hosts/##user_data_space##/##user_data_machinetype##/##user_data_machine_hostname##/##user_data_uuid##/"
+   fi
+  done
+)
+
+sleep 30
+
+) >##user_data_joboutputs_url##/user_data_script.log 2>&1 

--- a/Pilot/user_data_sc
+++ b/Pilot/user_data_sc
@@ -1,5 +1,29 @@
 #!/bin/sh
-
+#
+# Generic DIRAC pilot script for use with Singularity and Docker containers, 
+# containing the following ##user_data___## substitutions:
+#
+# user_data_jobfeatures_url
+# user_data_joboutputs_url
+# user_data_machine_hostname
+# user_data_machinefeatures_url
+# user_data_machinetype
+# user_data_option_dirac_opts
+# user_data_option_dirac_pilot_url
+# user_data_option_dirac_queue
+# user_data_option_hostcert
+# user_data_option_hostkey
+# user_data_option_x509_proxy
+# user_data_space
+# user_data_url
+# user_data_uuid
+#
+# Each substitution pattern may occur more than once in this template. If you
+# are reading a processed file, then these substitutions will already have 
+# been made below.
+#
+# Andrew.McNab@cern.ch October 2017
+#
 (
 date --utc +"%Y-%m-%d %H:%M:%S %Z user_data_sc Start user_data_sc on `hostname`"
 
@@ -10,7 +34,6 @@ export MACHINEFEATURES='##user_data_machinefeatures_url##'
 export JOBFEATURES='##user_data_jobfeatures_url##'
 export JOBOUTPUTS='##user_data_joboutputs_url##'
 
-export CE_NAME='##user_data_space##'
 export VM_UUID='##user_data_uuid##'
 
 if [ "$VM_UUID" = "" -a "$JOBFEATURES" != "" ] ; then
@@ -23,6 +46,7 @@ if [ "$VM_UUID" = "" ] ; then
 fi
 
 export JOB_ID="##user_data_space##:$VM_UUID:##user_data_machinetype##"
+export PILOT_UUID="sc://##user_data_space##/$JOB_ID"
 
 mkdir -p $HOME/grid-security
 export X509_USER_PROXY=$HOME/grid-security/x509proxy.pem

--- a/Pilot/user_data_vm
+++ b/Pilot/user_data_vm
@@ -297,17 +297,10 @@ fi
 chown -R plt.plt /scratch/plt
 chmod 1775 /scratch/plt
 
-# Uncomment for testing with dev.tgz
-#DEVOPTS='--commandExtensions dev,LHCbPilot --commands NagiosProbes,CheckWorkerNode,InstallDIRAC,UnpackDevDev,LHCbConfigureBasics,LHCbConfigureSite,LHCbConfigureArchitecture,LHCbConfigureCPURequirements,MultiLaunchAgent'
-
 if [ '##user_data_option_dirac_queue##' != '' ] ; then
   QUEUE='##user_data_option_dirac_queue##'
 else
   QUEUE=default
-fi
-
-if [ '##user_data_option_dirac_tag##' != '' ] ; then
-  TAGS="-o '/Resources/Computing/CEDefaults/Tag=##user_data_option_dirac_tag##'"
 fi
 
 # Now run the pilot script
@@ -316,13 +309,14 @@ fi
  JOB_ID="##user_data_space##:$VM_UUID:##user_data_machinetype##" \
  MACHINEFEATURES="$MACHINEFEATURES" JOBFEATURES="$JOBFEATURES" \
  python /scratch/plt/dirac-pilot.py \
- --debug $DEVOPTS $TAGS \
+ --debug \
  -o '/LocalSite/SubmitPool=Test' \
  --Name '##user_data_space##' \
  --Queue $QUEUE \
  --MaxCycles 1 \
  --CEType Sudo \
- --cert --certLocation=/scratch/plt/etc/grid-security \
+ --cert --certLocation /scratch/plt/etc/grid-security \
+ ##user_data_option_dirac_opts## \
  >/var/spool/joboutputs/dirac-pilot.log 2>&1
 
 # Save JobAgent and System logs

--- a/Pilot/user_data_vm
+++ b/Pilot/user_data_vm
@@ -56,7 +56,7 @@ Content-Disposition: attachment; filename="user_data_script"
 mkdir -p /var/spool/joboutputs
 (
 # Set the hostname if available; display otherwise
-hostname ##user_data_vm_hostname##
+hostname ##user_data_machine_hostname##
 date --utc +"%Y-%m-%d %H:%M:%S %Z user_data_script Start user_data on `hostname`"
 
 echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6
@@ -71,7 +71,6 @@ export JOBOUTPUTS='##user_data_joboutputs_url##'
 /bin/echo -e "export MACHINEFEATURES=$MACHINEFEATURES\nexport JOBFEATURES=$JOBFEATURES\nexport JOBOUTPUTS=$JOBOUTPUTS" > /etc/profile.d/mjf.sh
 /bin/echo -e "setenv MACHINEFEATURES $MACHINEFEATURES\nsetenv JOBFEATURES $JOBFEATURES\nsetenv JOBOUTPUTS $JOBOUTPUTS" > /etc/profile.d/mjf.csh
 
-export CE_NAME='##user_data_space##'
 export VM_UUID='##user_data_uuid##'
 
 if [ "$VM_UUID" = "" -a "$JOBFEATURES" != "" ] ; then
@@ -79,9 +78,12 @@ if [ "$VM_UUID" = "" -a "$JOBFEATURES" != "" ] ; then
 fi
 
 if [ "$VM_UUID" = "" ] ; then
-  # If still unset then just use the hostname from the VM lifecycle manager
-  export VM_UUID=`date +'%s.##user_data_vm_hostname##'`
+  # If still unset then just use date and hostname from the VM lifecycle manager
+  export VM_UUID=`date +'%s.##user_data_machine_hostname##'`
 fi
+
+export JOB_ID="##user_data_space##:$VM_UUID:##user_data_machinetype##"
+export PILOT_UUID="vm://##user_data_space##/$JOB_ID"
 
 # Create a shutdown_message if ACPI shutdown signal received
 /bin/echo -e 'echo "100 VM received ACPI shutdown signal from hypervisor" > /var/spool/joboutputs/shutdown_message\n/sbin/shutdown -h now' >/etc/acpi/actions/power.sh
@@ -306,8 +308,8 @@ fi
 # Now run the pilot script
 /usr/bin/sudo -i -n -u plt \
  X509_USER_PROXY=$X509_USER_PROXY \
- JOB_ID="##user_data_space##:$VM_UUID:##user_data_machinetype##" \
  MACHINEFEATURES="$MACHINEFEATURES" JOBFEATURES="$JOBFEATURES" \
+ JOB_ID="$JOB_ID" PILOT_UUID="$PILOT_UUID" \
  python /scratch/plt/dirac-pilot.py \
  --debug \
  -o '/LocalSite/SubmitPool=Test' \


### PR DESCRIPTION
This PR has updates to user_data_vm and adds user_data_sc (for Singularity containers and ok with Docker too).

In pilotCommands.py, the UnpackDev command is removed and a modified version of ReplaceDIRACCode from Pilot 2.0 is used instead. The main change is to use TGZ instead of ZIP, as the ZipFile module does not preserve the execute bit on scripts.

I've tidied up pilotTools.py, in particular ordering the list of options alphabetically, which identified one duplicate ("-C") marked with FIXME. I also removed a duplicate of the __initCommandLine2() function.

The functionality of Pilot 3.0 is otherwise unchanged.
