### PR TITLE
Add another pattern for 300 Nothing to do

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -1157,6 +1157,7 @@ class MultiLaunchAgent( CommandBase ):
         ###########################################################
         # We asked, but nothing more from the matcher.
         ['INFO: JobAgent will stop with message "Nothing to do for more than', '300 Nothing to do'],
+        ['Job request OK: No match found', '300 Nothing to do'],
 
         # Variants of: "400 Site/host/VM is currently banned/disabled from receiving more work"
         #######################################################################################


### PR DESCRIPTION
This fixes a problem seen in GridPP DIRAC where the JobAgent log file messages have changed, and the pilot fails to detect that no work was found. 