### PR TITLE
Remove Python 2.6 tests from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
 
 env:


### PR DESCRIPTION
It was not working anyway, so better not to add the noise.