### PR TITLE
Ensure maxNumberOfProcessors is int

### DIFF
--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -621,7 +621,7 @@ class PilotParams(object):
       elif o == '-p' or o == '--platform':
         self.platform = v
       elif o == '-m' or o == '--maxNumberOfProcessors':
-        self.maxNumberOfProcessors = v
+        self.maxNumberOfProcessors = int(v)
       elif o == '-D' or o == '--disk':
         try:
           self.minDiskSpace = int(v)


### PR DESCRIPTION
Matching patch for DIRACGrid/DIRAC/pull/4091: This forces maxNumberOfProcessors to be an int which prevents a min() expression from failing later in the code.