### PR TITLE
Payload processors

### DIFF
--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -506,9 +506,9 @@ class PilotParams(object):
 
     # Set number of allocatable processors from MJF if available
     try:
-      self.processors = int(urllib.urlopen(os.path.join(os.environ['JOBFEATURES'], 'allocated_cpu')).read())
+      self.pilotProcessors = int(urllib.urlopen(os.path.join(os.environ['JOBFEATURES'], 'allocated_cpu')).read())
     except BaseException:
-      self.processors = 1
+      self.pilotProcessors = 1
 
     # Pilot command options
     self.cmdOpts = (('', 'requiredTag=', 'extra required tags for resource description'),
@@ -545,6 +545,7 @@ class PilotParams(object):
                     ('M:', 'MaxCycles=', 'Maximum Number of JobAgent cycles to run'),
                     ('N:', 'Name=', 'CE Name'),
                     ('O:', 'OwnerDN=', 'Pilot OwnerDN (for private pilots)'),
+                    ('P:', 'pilotProcessors=', 'Number of processors allocated to this pilot'),
                     ('Q:', 'Queue=', 'Queue name'),
                     ('R:', 'reference=', 'Use this pilot reference'),
                     ('S:', 'setup=', 'DIRAC Setup to use'),
@@ -648,9 +649,9 @@ class PilotParams(object):
           pass
       elif o in ('-T', '--CPUTime'):
         self.jobCPUReq = v
-      elif o == '-P' or o == '--processors':
+      elif o == '-P' or o == '--pilotProcessors':
         try:
-          self.procesors = int(v)
+          self.pilotProcessors = int(v)
         except BaseException:
           pass
       elif o == '-z' or o == '--pilotLogging':

--- a/Pilot/user_data_vm
+++ b/Pilot/user_data_vm
@@ -71,11 +71,6 @@ export JOBOUTPUTS='##user_data_joboutputs_url##'
 /bin/echo -e "export MACHINEFEATURES=$MACHINEFEATURES\nexport JOBFEATURES=$JOBFEATURES\nexport JOBOUTPUTS=$JOBOUTPUTS" > /etc/profile.d/mjf.sh
 /bin/echo -e "setenv MACHINEFEATURES $MACHINEFEATURES\nsetenv JOBFEATURES $JOBFEATURES\nsetenv JOBOUTPUTS $JOBOUTPUTS" > /etc/profile.d/mjf.csh
 
-export VO='##user_data_option_vo##'
-if [ "$VO" == "" ] ; then
-  VO=lhcb
-fi
-
 export VM_UUID='##user_data_uuid##'
 if [ "$VM_UUID" = "" -a "$JOBFEATURES" != "" ] ; then
   export VM_UUID=`python -c "import urllib ; print urllib.urlopen('$JOBFEATURES/job_id').read().strip()"`
@@ -103,12 +98,6 @@ fi
 
 # Once we have finished with the metadata, stop any user process reading it later
 /sbin/iptables -A OUTPUT -d 169.254.169.254 -p tcp --dport 80 -j DROP 
-
-machine_syslog=`python -c "import urllib ; print urllib.urlopen('$MACHINEFEATURES/syslog').read().strip()"`
-if [ "$machine_syslog" ] ; then
- echo "*.* @$machinesyslog" > /etc/rsyslog.d/vm.conf
- /sbin/service rsyslog restart
-fi
 
 # Get the big 40GB+ logical partition as /scratch
 mkdir -p /scratch
@@ -305,7 +294,21 @@ fi
 chown -R plt.plt /scratch/plt
 chmod 1775 /scratch/plt
 
-SUBMIT_POOL_OPTS="-o '/LocalSite/SubmitPool=Test'"
+# This is not used within the user_data_script but it made available for include_vm_*.sh scripts
+export VO='##user_data_option_vo##'
+
+if [ '##user_data_option_submit_pool##' != '' ] ; then
+  export SUBMIT_POOL=##user_data_option_submit_pool##
+else
+  # Test matches any JobType
+  export SUBMIT_POOL=Test
+fi
+
+if [ '##user_data_option_dirac_queue##' != '' ] ; then
+  export QUEUE='##user_data_option_dirac_queue##'
+else
+  export QUEUE=default
+fi
 
 # Source any include scripts we fetched
 for i in include_vm_*.sh
@@ -315,12 +318,6 @@ do
  fi
 done
 
-if [ '##user_data_option_dirac_queue##' != '' ] ; then
-  QUEUE='##user_data_option_dirac_queue##'
-else
-  QUEUE=default
-fi
-
 # Now run the pilot script
 /usr/bin/sudo -i -n -u plt \
  X509_USER_PROXY=$X509_USER_PROXY \
@@ -328,7 +325,7 @@ fi
  JOB_ID="$JOB_ID" PILOT_UUID="$PILOT_UUID" \
  python /scratch/plt/dirac-pilot.py \
  --debug \
- $SUBMIT_POOL_OPTS \
+ -o /LocalSite/SubmitPool=$SUBMIT_POOL \
  --Name '##user_data_space##' \
  --Queue $QUEUE \
  --MaxCycles 1 \
@@ -349,7 +346,7 @@ cp -f /scratch/plt/bashrc /scratch/plt/jobagent.*.log /scratch/plt/shutdown_mess
     curl --capath $X509_CERT_DIR --cert /root/x509proxy.pem --cacert /root/x509proxy.pem --location --upload-file "$i" \
      "$JOBOUTPUTS/"
 
-    if [ "$DEPO_BASE_URL" != ""] ; then
+    if [ "$DEPO_BASE_URL" != "" ] ; then
       # This will be replaced by extended pilot logging??
       curl --capath $X509_CERT_DIR --cert /root/x509proxy.pem --cacert /root/x509proxy.pem --location --upload-file "$i" \
         "$DEPO_BASE_URL/##user_data_space##/##user_data_machinetype##/##user_data_machine_hostname##/##user_data_uuid##/"

--- a/Pilot/user_data_vm
+++ b/Pilot/user_data_vm
@@ -349,7 +349,7 @@ cp -f /scratch/plt/bashrc /scratch/plt/jobagent.*.log /scratch/plt/shutdown_mess
     if [ "$DEPO_BASE_URL" != "" ] ; then
       # This will be replaced by extended pilot logging??
       curl --capath $X509_CERT_DIR --cert /root/x509proxy.pem --cacert /root/x509proxy.pem --location --upload-file "$i" \
-        "$DEPO_BASE_URL/##user_data_space##/##user_data_machinetype##/##user_data_machine_hostname##/##user_data_uuid##/"
+        "$DEPO_BASE_URL/##user_data_space##/##user_data_machinetype##/##user_data_machine_hostname##/$VM_UUID/"
     fi
    fi
   done


### PR DESCRIPTION
This PR adds support for multiprocessor payloads in DIRAC VMs defined by user_data_vm. In the pilotTools/Commands, self.pp.payloadProcessors and self.pp.pilotProcessors are introduced which are available to other pilot commands (eg MultiLaunchAgent). Required tags and normal tags are now stored in CEDefaults by CheckWN rather than by CheckCE to allow MultiProcessor and NProcessors tags to be created when they have not been created as part of the pilot definition (eg inside a VM.) The MultiLaunchAgent now launches int(P/p) job agents where P is the number of processors allocated to the pilot (or VM) and p is the number of processors per payload.  

In CheckWN, self.cfg is used throughout instead of a mixture of cfg and self.cfg (which I think was just there for historical reasons?) 