### PR TITLE
Remove option to run pilot loggers from tests

### DIFF
--- a/tests/CI/pilot_ci.sh
+++ b/tests/CI/pilot_ci.sh
@@ -92,14 +92,14 @@ function PilotInstall(){
   sed -i "s#VAR_USERDN#$DIRACUSERDN#g" pilot.json
 
   prepareForPilot
-  installStompRequestsIfNecessary
+  #installStompRequestsIfNecessary
   #preparePythonEnvironment
-  python PilotLoggerTools.py PilotUUID
-  python PilotLogger.py "Hello I am THE best pilot"
+  #python PilotLoggerTools.py PilotUUID
+  #python PilotLogger.py "Hello I am THE best pilot"
 
   # launch the pilot script
   pilotOptions=$pilot_options
-  pilotOptions+=" -M 1 -S $DIRACSETUP -N $JENKINS_CE -Q $JENKINS_QUEUE -n $JENKINS_SITE --cert --certLocation=/home/dirac/certs --pilotLogging"
+  pilotOptions+=" -M 1 -S $DIRACSETUP -N $JENKINS_CE -Q $JENKINS_QUEUE -n $JENKINS_SITE --cert --certLocation=/home/dirac/certs"
   if [ $VO ]
   then
     pilotOptions+=" -l $VO -E $VO"


### PR DESCRIPTION
Apparently pilotLogger flag was on in the tests. By default it was trying to send messages to local file.
I turned that off.
Also,  the stomp/requests function is not necessary in that case