### PR TITLE
added nighly for uploading pilot 'tarballs' (for tests)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,35 @@
+name: Nightly
+
+on: 
+  schedule:
+    # every night at midnight
+    - cron:  '0 0 * * *'
+
+
+jobs:
+  # uploading master and devel tarballs to web server, for use in subsequent tests
+  upload:
+    runs-on: ubuntu-latest
+    if: github.repository == 'DIRACGrid/Pilot'
+
+    strategy:
+      fail-fast: False
+      matrix:
+        branch:
+          - master
+          - devel
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branch }}
+      - name: upload
+        run: |
+          cp tests/upload.sh deploy.sh
+          sed -i 's/lhcbprod/${{ secrets.KRB_USERNAME }}/g' deploy.sh && \
+          cat deploy.sh && "\
+          echo ${{ secrets.KRB_PASSWORD }} | kinit ${{ secrets.KRB_USERNAME }}@CERN.CH && \
+          echo readyToUpload && \
+          export USER=${{ secrets.KRB_USERNAME }} && \
+          echo reallyReadyToUpload && \
+          ./deploy.sh ${{ matrix.branch }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
       - name: upload
         run: |
           cp tests/upload.sh deploy.sh
-          sed -i 's/lhcbprod/${{ secrets.KRB_USERNAME }}/g' deploy.sh && \
+          sed -i 's/uploaduser/${{ secrets.KRB_USERNAME }}/g' deploy.sh && \
           cat deploy.sh && "\
           echo ${{ secrets.KRB_PASSWORD }} | kinit ${{ secrets.KRB_USERNAME }}@CERN.CH && \
           echo readyToUpload && \

--- a/tests/pilot.json
+++ b/tests/pilot.json
@@ -1,0 +1,41 @@
+{
+  "Setups": {
+    "CI": {
+      "CheckVersion": "True",
+      "Commands": {
+        "TEST": [
+          "CheckWorkerNode",
+          "InstallDIRAC"
+        ],
+      },
+      "Logging": {
+        "LoggingType":"LOCAL_FILE", 
+        "LocalOutputFile":"myFile"
+      },
+      "Version": "VAR_DIRAC_VERSION",
+    },
+    "Defaults": {
+      "Commands": {
+        "defaultList": [
+          "CheckWorkerNode",
+          "InstallDIRAC"
+        ],
+        "Defaults": [
+          "CheckWorkerNode",
+          "InstallDIRAC"
+        ]
+      },
+      "ConfigurationServer": "dips://does.not.matter.org:9162",
+      "GenericPilotGroup": "dirac_pilot",
+      "GenericPilotDN": "/just/a/dn"
+    }
+  },
+  "CEs": {
+    "ce.dirac.org": {
+      "Site": "DIRAC.CI.ORG",
+      "Queue": "DIRACQUEUE",
+      "GridCEType": "TEST"
+    }
+  },
+  "DefaultSetup": "CI"
+}

--- a/tests/pilot.json
+++ b/tests/pilot.json
@@ -6,13 +6,13 @@
         "TEST": [
           "CheckWorkerNode",
           "InstallDIRAC"
-        ],
+        ]
       },
       "Logging": {
         "LoggingType":"LOCAL_FILE", 
         "LocalOutputFile":"myFile"
       },
-      "Version": "VAR_DIRAC_VERSION",
+      "Version": "integration"
     },
     "Defaults": {
       "Commands": {

--- a/tests/upload.sh
+++ b/tests/upload.sh
@@ -1,0 +1,12 @@
+# Uploads a pilot.tar and a pilot.json to http://diracproject.web.cern.ch/diracproject/tars/Pilot/DIRAC/[directory]
+
+# temp work dir
+tmpdir=$(mktemp -d)
+echo $tmpdir
+cp Pilot/*.py $tmpdir
+cp tests/pilot.json $tmpdir
+
+# create the tar and upload
+cd $tmpdir
+tar -cf pilot.tar *.py
+( tar -cf - pilot.tar pilot.json ) | ssh lhcbprod@lxplus.cern.ch "cd /eos/project/d/diracgrid/www/tars/Pilot/DIRAC/${1}/ && tar -xvf - "

--- a/tests/upload.sh
+++ b/tests/upload.sh
@@ -9,4 +9,4 @@ cp tests/pilot.json $tmpdir
 # create the tar and upload
 cd $tmpdir
 tar -cf pilot.tar *.py
-( tar -cf - pilot.tar pilot.json ) | ssh lhcbprod@lxplus.cern.ch "cd /eos/project/d/diracgrid/www/tars/Pilot/DIRAC/${1}/ && tar -xvf - "
+( tar -cf - pilot.tar pilot.json ) | ssh uploaduser@lxplus.cern.ch "cd /eos/project/d/diracgrid/www/tars/Pilot/DIRAC/${1}/ && tar -xvf - "


### PR DESCRIPTION
This PR adds a "nightly" action for uploading the pilot files (in a tarball names pilot.tar) and a pilot.json file to a web server (basically: here https://diracproject.web.cern.ch/diracproject/tars/Pilot/DIRAC/).
The result can be visible in https://diracproject.web.cern.ch/diracproject/tars/Pilot/DIRAC/master/

The pilot.tar and pilot.json files are then used by these tests: https://github.com/DIRACGrid/DIRAC/pull/4392/files