### PR TITLE
Add JobAgent options: pollingTime, stopAppFailure, stopFailedMatches

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -839,7 +839,10 @@ class LaunchAgent(CommandBase):
     self.inProcessOpts = ['-s /Resources/Computing/CEDefaults']
     self.inProcessOpts.append('-o WorkingDirectory=%s' % self.pp.workingDir)
     self.inProcessOpts.append('-o /LocalSite/CPUTime=%s' % (int(self.pp.jobCPUReq)))
-    self.jobAgentOpts = ['-o MaxCycles=%s' % self.pp.maxCycles]
+    self.jobAgentOpts = ['-o MaxCycles=%s' % self.pp.maxCycles,
+                         '-o PollingTime=%s' % self.pp.pollingTime,
+                         '-o StopOnApplicationFailure=%s' % self.pp.stopOnApplicationFailure,
+                         '-o StopAfterFailedMatches=%s' % self.pp.stopAfterFailedMatches]
 
     if self.debugFlag:
       self.jobAgentOpts.append('-o LogLevel=DEBUG')
@@ -938,6 +941,8 @@ class MultiLaunchAgent(CommandBase):
     # To prevent a wayward agent picking up and failing many jobs.
     self.inProcessOpts.append('-o MaxTotalJobs=%s' % self.pp.maxCycles)
     self.jobAgentOpts = ['-o MaxCycles=%s' % self.pp.maxCycles,
+                         '-o PollingTime=%s' % self.pp.pollingTime,
+                         '-o StopOnApplicationFailure=%s' % self.pp.stopOnApplicationFailure,
                          '-o StopAfterFailedMatches=0']
 
     if self.debugFlag:

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -445,8 +445,6 @@ class PilotParams(object):
   """ Class that holds the structure with all the parameters to be used across all the commands
   """
 
-  MAX_CYCLES = 10
-
   def __init__(self):
     """ c'tor
 
@@ -488,7 +486,10 @@ class PilotParams(object):
     self.pythonVersion = '27'
     self.userGroup = ""
     self.userDN = ""
-    self.maxCycles = self.MAX_CYCLES
+    self.maxCycles = 10
+    self.pollingTime = 120
+    self.stopOnApplicationFailure = True
+    self.stopAfterFailedMatches = 10
     self.flavour = 'DIRAC'
     self.gridVersion = ''
     self.pilotReference = ''
@@ -559,6 +560,9 @@ class PilotParams(object):
                     ('G:', 'Group=', 'DIRAC Group to use'),
                     ('K:', 'certLocation=', 'Specify server certificate location'),
                     ('M:', 'MaxCycles=', 'Maximum Number of JobAgent cycles to run'),
+                    ('', 'PollingTime=', 'JobAgent execution frequency'),
+                    ('', 'StopOnApplicationFailure=', 'Stop Job Agent when encounter an application failure'),
+                    ('', 'StopAfterFailedMatches=', 'Stop Job Agent after N failed matches'),
                     ('N:', 'Name=', 'CE Name'),
                     ('O:', 'OwnerDN=', 'Pilot OwnerDN (for private pilots)'),
                     ('P:', 'pilotProcessors=', 'Number of processors allocated to this pilot'),
@@ -660,7 +664,19 @@ class PilotParams(object):
         self.certsLocation = v
       elif o == '-M' or o == '--MaxCycles':
         try:
-          self.maxCycles = min(self.MAX_CYCLES, int(v))
+          self.maxCycles = int(v)
+        except ValueError:
+          pass
+      elif o == '--PollingTime':
+        try:
+          self.pollingTime = int(v)
+        except ValueError:
+          pass
+      elif o == '--StopOnApplicationFailure':
+        self.stopOnApplicationFailure = v
+      elif o == '--StopAfterFailedMatches':
+        try:
+          self.stopAfterFailedMatches = int(v)
         except ValueError:
           pass
       elif o in ('-T', '--CPUTime'):


### PR DESCRIPTION
This PR adds options related to `JobAgent` and bound to the `PoolCE` usage:
* `pollingTime`: mainly to reduce the polling time of `JobAgent` as it usually takes 30sec to submit a job to the `PoolCE`. It allows to start running multiple jobs quicker.
* `stopOnApplicationFailure`: boolean that can be set to `False` to avoid `JobAgent` to finish when an error occurs within a job. The `PoolCE` can run several jobs at the same time and we could continue the execution. Moreover, on batch systems, it could avoid to waste allocated time.
* `stopAfterFailedMatches`: same idea

It also removes the `MAX_CYCLES = 10` attribute limiting the number of cycles in `JobAgent` to 10.
As we may encounter some nodes having 24 or even 96 processors where we can run more than 10 jobs, we should be able to set `MaxCycles` without being limited.