### PR TITLE
Revert "if etc/dirac.cfg does not exist, create it as a symlink to pilot.cfg"

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -322,8 +322,6 @@ class ConfigureBasics(CommandBase):
     if retCode:
       self.log.error("Could not configure DIRAC basics [ERROR %d]" % retCode)
       self.exitWithError(retCode)
-    if not os.path.isfile("etc/dirac.cfg"):
-      os.symlink(os.path.join("..", self.pp.localConfigFile), "etc/dirac.cfg")
 
   def _getBasicsCFG(self):
     """  basics (needed!)


### PR DESCRIPTION
Reverts DIRACGrid/Pilot#108

Fails in LHCb with e.g.
```
Traceback (most recent call last):
  File "dirac-pilot.py", line 66, in <module>
    command.execute()
  File "/home/iris/pltlhcb016/home_cream_913165079/CREAM913165079/DIRAC_1G9oWrpilot/pilotCommands.py", line 326, in execute
    os.symlink(os.path.join("..", self.pp.localConfigFile), "etc/dirac.cfg")
OSError: [Errno 2] No such file or directory
Traceback (most recent call last):
  File "<stdin>", line 162, in <module>
  File "/usr/lib64/python2.7/shutil.py", line 256, in rmtree
    onerror(os.rmdir, path, sys.exc_info())
  File "/usr/lib64/python2.7/shutil.py", line 254, in rmtree
    os.rmdir(path)
OSError: [Errno 39] Directory not empty: '/home/iris/pltlhcb016/home_cream_913165079/CREAM913165079/DIRAC_1G9oWrpilot'
```

@marianne013 