### PR TITLE
Ensure pilot command output is always ascii

### DIFF
--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -381,10 +381,13 @@ class CommandBase(object):
                             stderr=subprocess.PIPE, close_fds=False)
 
       # standard output
-      outData = _p.stdout.read().decode().strip()
-      for line in outData:
-        sys.stdout.write(str(line))
-      sys.stdout.write('\n')
+      outData = _p.stdout.read()
+      # always convert the output to ascii
+      outData = outData.decode("ascii", "replace")
+      # replace any invalid characters with "?" to avoid having unicode output
+      outData = str(outData.replace(u"\ufffd", "?").strip())
+      # write to stdout for debugging
+      sys.stdout.write(outData + '\n')
 
       for line in _p.stderr:
         sys.stderr.write(str(line))

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -382,7 +382,7 @@ class CommandBase(object):
 
       # standard output
       outData = _p.stdout.read()
-      # always convert the output to ascii
+      # always interpret the output as ascii
       outData = outData.decode("ascii", "replace")
       # replace any invalid characters with "?" to avoid having unicode output
       outData = str(outData.replace(u"\ufffd", "?").strip())


### PR DESCRIPTION
This PR ensures the return value of `executeAndGetOutput` is always valid ascii. Any invalid bytes are replaced with `?`. I've tested this will all sorts of odd locales and Python versions, including 2.6, 2.7 and 3.8. See the screenshot for examples.

In principle something similar could be done for `stderr` but it's only printed to `sys.stdout` so I don't think it's necessary.

Fixes #112
Closes #114 

![Screenshot 2020-07-23 at 17 36 39](https://user-images.githubusercontent.com/5220533/88307473-476f4e80-cd0c-11ea-8fc2-240056ff961b.png)