### PR TITLE
Install a py3 client + large simplifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ This is customized pipeline for running on jenkins-dirac.web.cern.ch
 */
 
 
-properties([parameters([string(name: 'projectVersion', defaultValue: 'v7r2', description: 'The DIRAC version to install'),
+properties([parameters([string(name: 'projectVersion', defaultValue: 'v7r2', description: 'The DIRAC version to install. For py3 use e.g. DIRAC[pilot]==7.2.0'),
                         string(name: 'Pilot_repo', defaultValue: 'DIRACGrid', description: 'The Pilot repo'),
                         string(name: 'Pilot_branch', defaultValue: 'master', description: 'The Pilot branch'),
                         string(name: 'DIRAC_test_repo', defaultValue: 'DIRACGrid', description: 'The DIRAC repo to use for getting the test code'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,6 +81,7 @@ node('lhcbci-cernvm4-02') {
                             dir(env.WORKSPACE+"/PilotInstallDIR"){
                                 sh '''
                                     bash -c "source bashrc;\
+                                    source diracos/diracosrc;\
                                     source \$WORKSPACE/TestCode/Pilot/tests/CI/pilot_ci.sh;\
                                     downloadProxy;\
                                     export PYTHONPATH=\$PYTHONPATH:\$WORKSPACE/TestCode:\$WORKSPACE/TestCode/DIRAC:\$WORKSPACE/TestCode/Pilot;\
@@ -111,6 +112,7 @@ node('lhcbci-cernvm4-02') {
                             dir(env.WORKSPACE+"/PilotInstallDIR"){
                                 sh '''
                                     bash -c "source bashrc;\
+                                    source diracos/diracosrc;\
                                     source \$WORKSPACE/TestCode/Pilot/tests/CI/pilot_ci.sh;\
                                     downloadProxy;\
                                     export PYTHONPATH=\$PYTHONPATH:\$WORKSPACE/TestCode:\$WORKSPACE/TestCode/DIRAC:\$WORKSPACE/TestCode/Pilot;\
@@ -133,3 +135,4 @@ node('lhcbci-cernvm4-02') {
         }
     }
 }
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,6 @@ node('lhcbci-cernvm4-02') {
                                     source diracos/diracosrc;\
                                     source \$WORKSPACE/TestCode/Pilot/tests/CI/pilot_ci.sh;\
                                     downloadProxy;\
-                                    export PYTHONPATH=\$PYTHONPATH:\$WORKSPACE/TestCode:\$WORKSPACE/TestCode/DIRAC:\$WORKSPACE/TestCode/Pilot;\
                                     python \$WORKSPACE/TestCode/DIRAC/tests/Workflow/Integration/Test_UserJobs.py pilot.cfg -o /DIRAC/Security/UseServerCertificate=no -ddd"
                                 '''
                             }
@@ -115,7 +114,6 @@ node('lhcbci-cernvm4-02') {
                                     source diracos/diracosrc;\
                                     source \$WORKSPACE/TestCode/Pilot/tests/CI/pilot_ci.sh;\
                                     downloadProxy;\
-                                    export PYTHONPATH=\$PYTHONPATH:\$WORKSPACE/TestCode:\$WORKSPACE/TestCode/DIRAC:\$WORKSPACE/TestCode/Pilot;\
                                     python \$WORKSPACE/TestCode/DIRAC/tests/Workflow/Regression/Test_RegressionUserJobs.py pilot.cfg -o /DIRAC/Security/UseServerCertificate=no -ddd"
                                 '''
                             }

--- a/Pilot/dirac-install.py
+++ b/Pilot/dirac-install.py
@@ -1358,8 +1358,8 @@ def downloadAndExtractTarball(tarsURL, pkgName, pkgVer, checkHash=True, cache=Fa
 
 def discoverModules(modules):
   """
-  Created the dictionary which contains all modules, which can be installed
-  for example: {"DIRAC:{"sourceUrl":"https://github.com/zmathe/DIRAC.git","Vesrion:v6r20p11"}}
+  Creates the dictionary which contains all modules to install
+  for example: {"DIRAC:{"sourceUrl":"https://github.com/zmathe/DIRAC.git","Version:v6r20p11"}}
 
   :param: str modules: it contains meta information for the module,
   which will be installed: https://github.com/zmathe/DIRAC.git:::DIRAC:::dev_main_branch
@@ -1398,11 +1398,9 @@ cmdOpts = (('r:', 'release=', 'Release version to install'),
            ('h', 'help', 'Show this help'),
            ('T:', 'Timeout=', 'Timeout for downloads (default = %s)'),
            ('  ', 'dirac-os-version=', 'the version of the DIRAC OS'),
-           ('  ', 'dirac-os', 'Enable installation of DIRAC OS'),
            ('  ', 'tag=', 'release version to install from git, http or local'),
            ('m:', 'module=',
             'Module to be installed. for example: -m DIRAC or -m git://github.com/DIRACGrid/DIRAC.git:DIRAC'),
-           ('x:', 'external=', 'external version'),
            ('  ', 'createLink', 'create version symbolic link from the versions directory. This is equivalent to the \
            following command: ln -s /opt/dirac/versions/vArBpC vArBpC'),
            ('  ', 'userEnvVariables=',

--- a/Pilot/dirac-install.py
+++ b/Pilot/dirac-install.py
@@ -1721,7 +1721,7 @@ def checkoutFromGit(moduleName, sourceURL, tagVersion, destinationDir=None):
     logNOTICE("Executing: %s" % cmd)
     retVal = os.system(cmd)
   else:
-    cmd = "mv %s/src/DIRAC %s" % (fDirName, os.path.join(cliParams.targetPath, moduleName))
+    cmd = "mv %s/src/%s %s" % (fDirName, moduleName, os.path.join(cliParams.targetPath, moduleName))
     logNOTICE("Executing: %s" % cmd)
     retVal = os.system(cmd)
     if not retVal:

--- a/Pilot/dirac-install.py
+++ b/Pilot/dirac-install.py
@@ -1,135 +1,6 @@
 #!/usr/bin/env python
 """
-The main DIRAC installer script. It can be used to install the main DIRAC software, its
-modules, web, rest etc. and DIRAC extensions.
-
-In order to deploy DIRAC you have to provide: globalDefaultsURL, which is by default:
-"http://diracproject.web.cern.ch/diracproject/configs/globalDefaults.cfg", but it can be
-in the local file system in a separate directory. The content of this file is the following::
-
-  Installations
-  {
-    DIRAC
-    {
-       DefaultsLocation =  http://diracproject.web.cern.ch/diracproject/dirac.cfg
-       LocalInstallation
-       {
-        PythonVersion = 27
-       }
-       # in case you have a DIRAC extension
-       LHCb
-      {
-      DefaultsLocation = http://lhcb-rpm.web.cern.ch/lhcb-rpm/lhcbdirac/lhcb.cfg
-      }
-    }
-  }
-  Projects
-  {
-    DIRAC
-    {
-      DefaultsLocation =  http://diracproject.web.cern.ch/diracproject/dirac.cfg
-    }
-    # in case you have a DIRAC extension
-    LHCb
-    {
-      DefaultsLocation = http://lhcb-rpm.web.cern.ch/lhcb-rpm/lhcbdirac/lhcb.cfg
-    }
-  }
-
-the DefaultsLocation for example::
-
-  DefaultsLocation = http://diracproject.web.cern.ch/diracproject/dirac.cfg
-
-must contain a minimal configuration. The following options must be in this
-file::
-
-  Releases=,UploadCommand=,BaseURL=
-
-In case you want to overwrite the global configuration file, you have to use --defaultsURL
-
-After providing the default configuration files, DIRAC or your extension can be installed from:
-
-1. in a directory you have to be present globalDefaults.cfg, dirac.cfg and all binaries.
-   For example::
-
-    zmathe@dzmathe zmathe]$ ls tars/
-    dirac.cfg  diracos-0.1.md5  diracos-0.1.tar.gz  DIRAC-v6r20-pre16.md5  DIRAC-v6r20-pre16.tar.gz
-    globalDefaults.cfg release-DIRAC-v6r20-pre16.cfg  release-DIRAC-v6r20-pre16.md5
-    zmathe@dzmathe zmathe]$
-
-   For example::
-
-    dirac-install -r v6r20-pre16 --dirac-os --dirac-os-version=0.0.1 -u /home/zmathe/tars
-
-   this command will use  /home/zmathe/tars directory for the source code.
-   It will install DIRAC v6r20-pre16, DIRAC OS 0.1 version
-
-2. You can use your dedicated web server or the official DIRAC web server
-
-   for example::
-
-    dirac-install -r v6r20-pre16 --dirac-os --dirac-os-version=0.0.1
-
-   It will install DIRAC v6r20-pre16
-
-   You can install an extension of diracos.
-
-   for example::
-
-     dirac-install -r v9r4-pre2 -l LHCb --dirac-os --dirac-os-version=LHCb:master
-
-3. You have possibility to install a not-yet-released DIRAC, module or extension using -m or --tag options.
-   The non release version can be specified.
-
-   for example::
-
-    dirac-install -l DIRAC -r v6r20-pre16 -g v14r0 -t client -m DIRAC --tag=integration
-
-   It will install DIRAC v6r20-pre16, where the DIRAC package based on integration, other other packages will be
-   the same what is specified in release.cfg file in v6r20-pre16 tarball.
-
-    dirac-install -l DIRAC -r v6r20-pre16 -g v14r0 -t client  -m DIRAC --tag=v6r20-pre22
-
-   It installs a specific tag
-
-   Note: If the source is not provided, DIRAC repository is used, which is defined in the global
-   configuration file.
-
-   We can provide the repository url:code repository:::Project:::branch. for example::
-
-     dirac-install -l DIRAC -r v6r20-pre16 -g v14r0 -t client \\
-     -m https://github.com/zmathe/DIRAC.git:::DIRAC:::dev_main_branch, \\
-     https://github.com/zmathe/WebAppDIRAC.git:::WebAppDIRAC:::extjs6 -e WebAppDIRAC
-
-   it will install DIRAC based on dev_main_branch and WebAppDIRAC based on extjs6::
-
-     dirac-install -l DIRAC -r v6r20-pre16 -g v14r0 -t client \\
-     -m WebAppDIRAC --tag=integration -e WebAppDIRAC
-
-   it will install DIRAC v6r20-pre16 and WebAppDIRAC integration branch
-
-You can use install.cfg configuration file::
-
-  DIRACOS = http://lhcb-rpm.web.cern.ch/lhcb-rpm/dirac/DIRACOS/
-  WebAppDIRAC = https://github.com/zmathe/WebAppDIRAC.git
-  DIRAC=https://github.com/DIRACGrid/DIRAC.git
-  LocalInstallation
-  {
-    # Project = LHCbDIRAC
-    # The project LHCbDIRAC is not defined in the globalsDefaults.cfg
-    Project = LHCb
-    Release = v9r2-pre8
-    Extensions = LHCb
-    ConfigurationServer = dips://lhcb-conf-dirac.cern.ch:9135/Configuration/Server
-    Setup = LHCb-Production
-    SkipCAChecks = True
-    SkipCADownload = True
-    WebAppDIRAC=extjs6
-    DIRAC=rel-v6r20
-  }
-
-  dirac-install -l LHCb -r v9r2-pre8 -t server --dirac-os --dirac-os-version=0.0.6 install.cfg
-
+dirac-install.py for Pilot (simplified)
 """
 
 #  pylint: skip-file
@@ -144,11 +15,8 @@ import signal
 import time
 import stat
 import shutil
-import subprocess
 import ssl
 import hashlib
-
-from distutils.version import LooseVersion   # pylint: disable=no-name-in-module,import-error
 
 try:
   # For Python 3.0 and later
@@ -185,26 +53,16 @@ class Params(object):
     self.project = 'DIRAC'
     self.installation = 'DIRAC'
     self.release = ""
-    self.externalsType = 'client'
-    self.pythonVersion = '27'
     self.platform = ""
     self.basePath = os.getcwd()
     self.targetPath = os.getcwd()
-    self.buildExternals = False
-    self.noAutoBuild = False
     self.debug = False
-    self.externalsOnly = False
-    self.lcgVer = ''
-    self.noLcg = False
-    self.useVersionsDir = False
     self.installSource = ""
     self.globalDefaults = False
     self.timeout = 300
     self.diracOSVersion = ''
-    self.diracOS = False
     self.tag = ""
     self.modules = {}
-    self.externalVersion = ""
     self.createLink = False
     self.scriptSymlink = False
     self.userEnvVariables = {}
@@ -518,12 +376,6 @@ class ReleaseConfig(object):
     self.instName = instName
     self.projectName = projectName
 
-  def setDebugCB(self, debFunc):
-    """
-    It is used by the dirac-distribution. It sets the debug function
-    """
-    self.debugCB = debFunc
-
   def __dbgMsg(self, msg):
     """
     :param str msg: the debug message
@@ -786,19 +638,6 @@ class ReleaseConfig(object):
       if location:
         logDEBUG("Using DIRACOS tarball URL from configuration key %s" % key)
         return location
-
-  def getUploadCommand(self, project=None):
-    """
-    It returns the command used to upload the binary
-
-    :param str project: the name of the project
-    """
-    if not project:
-      project = self.projectName
-    defLoc = self.globalDefaults.get("Projects/%s/UploadCommand" % project, "")
-    if defLoc:
-      return S_OK(defLoc)
-    return S_ERROR("No UploadCommand for %s" % project)
 
   def __loadReleaseConfig(self, project, release, releaseMode, sourceURL=None, relLocation=None):
     """
@@ -1125,24 +964,6 @@ class ReleaseConfig(object):
       return S_OK((False, modTpl[0]))
     return S_OK((modTpl[0], modTpl[1]))
 
-  def getExternalsVersion(self, release=None):
-    """
-    It returns the version of DIRAC Externals. If it is not provided,
-    uses the default cfg
-
-    :param str release: the release version
-    """
-
-    if 'DIRAC' not in self.prjRelCFG:
-      return False
-    if not release:
-      release = list(self.prjRelCFG['DIRAC'])
-      release = sorted(release, key=LooseVersion)[-1]
-    try:
-      return self.prjRelCFG['DIRAC'][release].get('Releases/%s/Externals' % release)
-    except KeyError:
-      return False
-
   def getDiracOSExtensionAndVersion(self, diracOSVersion):
     """
     This method return the diracos and version taking into
@@ -1178,20 +999,6 @@ class ReleaseConfig(object):
     except KeyError:
       pass
     return self.getDiracOSExtensionAndVersion(diracOSVersion)
-
-  def getLCGVersion(self, lcgVersion=None):
-    """
-    It returns the LCG version
-    :param str lcgVersion: LCG version
-    """
-    if lcgVersion:
-      return lcgVersion
-    try:
-      return self.prjRelCFG[self.projectName][cliParams.release].get(
-          "Releases/%s/LcgVer" % cliParams.release, lcgVersion)
-    except KeyError:
-      pass
-    return lcgVersion
 
   def getModulesToInstall(self, release, extensions=None):
     """
@@ -1594,44 +1401,6 @@ def fixPythonShebang():
     pass
 
 
-def runExternalsPostInstall():
-  """
-   If there are any postInstall in externals, run them
-  """
-  if cliParams.diracOS or cliParams.diracOSVersion:
-    postInstallPath = os.path.join(cliParams.targetPath, "postInstall")
-  else:
-    postInstallPath = os.path.join(cliParams.targetPath, cliParams.platform, "postInstall")
-  if not os.path.isdir(postInstallPath):
-    logDEBUG("There's no %s directory. Skipping postInstall step" % postInstallPath)
-    return
-  postInstallSuffix = "-postInstall"
-  for scriptName in os.listdir(postInstallPath):
-    if not scriptName.endswith(postInstallSuffix):
-      logDEBUG("%s does not have the %s suffix. Skipping.." % (scriptName, postInstallSuffix))
-      continue
-    scriptPath = os.path.join(postInstallPath, scriptName)
-    os.chmod(scriptPath, executablePerms)
-    logNOTICE("Executing %s..." % scriptPath)
-    if os.system("'%s' > '%s.out' 2> '%s.err'" % (scriptPath, scriptPath, scriptPath)):
-      logERROR("Post installation script %s failed. Check %s.err" % (scriptPath, scriptPath))
-      sys.exit(1)
-
-
-def fixMySQLScript():
-  """
-   Update the mysql.server script (if installed) to point to the proper datadir
-  """
-  scriptPath = os.path.join(cliParams.targetPath, 'scripts', 'dirac-fix-mysql-script')
-  bashrcFile = os.path.join(cliParams.targetPath, 'bashrc')
-  if cliParams.useVersionsDir:
-    bashrcFile = os.path.join(cliParams.basePath, 'bashrc')
-  command = 'source %s; %s > /dev/null' % (bashrcFile, scriptPath)
-  if os.path.exists(scriptPath):
-    logNOTICE("Executing %s..." % command)
-    os.system('bash -c "%s"' % command)
-
-
 def checkPlatformAliasLink():
   """
   Make a link if there's an alias
@@ -1639,23 +1408,6 @@ def checkPlatformAliasLink():
   if cliParams.platform in platformAlias:
     os.symlink(os.path.join(cliParams.targetPath, platformAlias[cliParams.platform]),
                os.path.join(cliParams.targetPath, cliParams.platform))
-
-
-def installExternalRequirements(extType):
-  """ Install the extension requirements if any
-  """
-  reqScript = os.path.join(cliParams.targetPath, "scripts", 'dirac-externals-requirements')
-  bashrcFile = os.path.join(cliParams.targetPath, 'bashrc')
-  if cliParams.useVersionsDir:
-    bashrcFile = os.path.join(cliParams.basePath, 'bashrc')
-  if os.path.isfile(reqScript):
-    os.chmod(reqScript, executablePerms)
-    logNOTICE("Executing %s..." % reqScript)
-    command = "%s -t '%s' > '%s.out' 2> '%s.err'" % (reqScript, extType, reqScript, reqScript)
-    if os.system('bash -c "source %s; %s"' % (bashrcFile, command)):
-      logERROR("Requirements installation script %s failed. Check %s.err" % (reqScript,
-                                                                             reqScript))
-  return True
 
 
 def discoverModules(modules):
@@ -1691,19 +1443,12 @@ def discoverModules(modules):
 cmdOpts = (('r:', 'release=', 'Release version to install'),
            ('l:', 'project=', 'Project to install'),
            ('e:', 'extensions=', 'Extensions to install (comma separated)'),
-           ('t:', 'installType=', 'Installation type (client/server)'),
-           ('i:', 'pythonVersion=', 'Python version to compile (27/26)'),
            ('p:', 'platform=', 'Platform to install'),
            ('P:', 'installationPath=', 'Path where to install (default current working dir)'),
            ('b', 'build', 'Force local compilation'),
-           ('g:', 'grid=', 'lcg tools package version'),
-           ('  ', 'no-lcg-bundle', 'lcg tools not to be installed'),
-           ('B', 'noAutoBuild', 'Do not build if not available'),
-           ('v', 'useVersionsDir', 'Use versions directory'),
            ('u:', 'baseURL=', "Use URL as the source for installation tarballs"),
            ('d', 'debug', 'Show debug messages'),
            ('V:', 'installation=', 'Installation from which to extract parameter values'),
-           ('X', 'externalsOnly', 'Only install external binaries'),
            ('M:', 'defaultsURL=', 'Where to retrieve the global defaults from'),
            ('h', 'help', 'Show this help'),
            ('T:', 'Timeout=', 'Timeout for downloads (default = %s)'),
@@ -1731,12 +1476,6 @@ def usage():
   for options in [('Release', cliParams.release),
                   ('Project', cliParams.project),
                   ('ModulesToInstall', []),
-                  ('ExternalsType', cliParams.externalsType),
-                  ('PythonVersion', cliParams.pythonVersion),
-                  ('LcgVer', cliParams.lcgVer),
-                  ('UseVersionsDir', cliParams.useVersionsDir),
-                  ('BuildExternals', cliParams.buildExternals),
-                  ('NoAutoBuild', cliParams.noAutoBuild),
                   ('Debug', cliParams.debug),
                   ('Timeout', cliParams.timeout)]:
     print(" %s = %s" % options)
@@ -1775,18 +1514,13 @@ def loadConfiguration():
 
   releaseConfig.loadInstallationLocalDefaults(args)
 
-  for opName in ('release', 'externalsType', 'installType', 'pythonVersion',
-                 'buildExternals', 'noAutoBuild', 'debug', 'globalDefaults',
-                 'lcgVer', 'useVersionsDir', 'targetPath',
-                 'project', 'release', 'extensions', 'timeout'):
+  for opName in ('release', 'debug', 'globalDefaults',
+                 'targetPath', 'project', 'release', 'extensions', 'timeout'):
     try:
       opVal = releaseConfig.getInstallationConfig(
           "LocalInstallation/%s" % (opName[0].upper() + opName[1:]))
     except KeyError:
       continue
-
-    if opName == 'installType':
-      opName = 'externalsType'
 
     if isinstance(getattr(cliParams, opName), str_type):
       setattr(cliParams, opName, opVal)
@@ -1805,18 +1539,10 @@ def loadConfiguration():
       for pkg in [p.strip() for p in v.split(",") if p.strip()]:
         if pkg not in cliParams.extensions:
           cliParams.extensions.append(pkg)
-    elif o in ('-t', '--installType'):
-      cliParams.externalsType = v
-    elif o in ('-i', '--pythonVersion'):
-      cliParams.pythonVersion = v
     elif o in ('-p', '--platform'):
       cliParams.platform = v
     elif o in ('-d', '--debug'):
       cliParams.debug = True
-    elif o in ('-g', '--grid'):
-      cliParams.lcgVer = v
-    elif o in ('--no-lcg-bundle'):
-      cliParams.noLcg = True
     elif o in ('-u', '--baseURL'):
       cliParams.installSource = v
     elif o in ('-P', '--installationPath'):
@@ -1825,14 +1551,6 @@ def loadConfiguration():
         os.makedirs(v)
       except BaseException:
         pass
-    elif o in ('-v', '--useVersionsDir'):
-      cliParams.useVersionsDir = True
-    elif o in ('-b', '--build'):
-      cliParams.buildExternals = True
-    elif o in ("-B", '--noAutoBuild'):
-      cliParams.noAutoBuild = True
-    elif o in ('-X', '--externalsOnly'):
-      cliParams.externalsOnly = True
     elif o in ('-T', '--Timeout'):
       try:
         cliParams.timeout = max(cliParams.timeout, int(v))
@@ -1841,14 +1559,10 @@ def loadConfiguration():
         pass
     elif o == '--dirac-os-version':
       cliParams.diracOSVersion = v
-    elif o == '--dirac-os':
-      cliParams.diracOS = True
     elif o == '--tag':
       cliParams.tag = v
     elif o in ('-m', '--module'):
       cliParams.modules = discoverModules(v)
-    elif o in ('-x', '--external'):
-      cliParams.externalVersion = v
     elif o == '--createLink':
       cliParams.createLink = True
     elif o == '--scriptSymlink':
@@ -1862,19 +1576,6 @@ def loadConfiguration():
     usage()
 
   cliParams.basePath = cliParams.targetPath
-  if cliParams.useVersionsDir:
-    # install under <installPath>/versions/<version>_<timestamp>
-    cliParams.targetPath = os.path.join(
-        cliParams.targetPath, 'versions', '%s_%s' % (cliParams.release, int(time.time())))
-    try:
-      os.makedirs(cliParams.targetPath)
-    except BaseException:
-      pass
-
-  # If we are running an update, DIRACOS will be set in the environment
-  if not cliParams.diracOS and 'DIRACOS' in os.environ:
-    logWARN("Forcing to install DIRACOS, because it is already installed!")
-    cliParams.diracOS = True
 
   logNOTICE("Destination path for installation is %s" % cliParams.targetPath)
   releaseConfig.projectName = cliParams.project
@@ -1892,428 +1593,6 @@ def loadConfiguration():
   releaseConfig.loadInstallationLocalDefaults(args)
 
   return S_OK(releaseConfig)
-
-
-def getPlatform():
-  """
-  It returns the platform, where this script is running using Platform.py
-  """
-  platformPath = os.path.join(cliParams.targetPath, "DIRAC", "Core", "Utilities", "Platform.py")
-  try:
-    platFD = open(platformPath, "r")
-  except IOError:
-    platformPath = os.path.join(cliParams.targetPath, "src", "DIRAC", "Core", "Utilities", "Platform.py")
-    try:
-      platFD = open(platformPath, "r")
-    except IOError:
-      platformPath = os.path.join(cliParams.targetPath, "DIRAC", "src", "DIRAC", "Core", "Utilities", "Platform.py")
-      try:
-        platFD = open(platformPath, "r")
-      except IOError:
-        logERROR("Cannot open Platform.py. Is DIRAC installed?")
-        return ''
-
-  Platform = imp.load_module("Platform", platFD, platformPath, ("", "r", imp.PY_SOURCE))
-  platFD.close()
-  return Platform.getPlatformString()
-
-
-def installExternals(releaseConfig):
-  """
-  It install the DIRAC external. The version of the external is provided by
-  the cmd or in the configuration file.
-
-  :param object releaseConfig:
-  """
-  if not releaseConfig:
-    externalsVersion = cliParams.externalVersion
-  else:
-    externalsVersion = releaseConfig.getExternalsVersion()
-  if not externalsVersion:
-    logERROR("No externals defined")
-    return False
-
-  if not cliParams.platform:
-    cliParams.platform = getPlatform()
-  if not cliParams.platform:
-    return False
-
-  if cliParams.installSource:
-    tarsURL = cliParams.installSource
-  else:
-    tarsURL = releaseConfig.getTarsLocation('DIRAC')['Value']
-
-  logDEBUG("Using platform: %s" % cliParams.platform)
-  extVer = "%s-%s-%s-python%s" % (cliParams.externalsType, externalsVersion,
-                                  cliParams.platform, cliParams.pythonVersion)
-  logDEBUG("Externals %s are to be installed" % extVer)
-  if not downloadAndExtractTarball(tarsURL, "Externals", extVer, cache=True):
-    return (not cliParams.noAutoBuild)
-  logNOTICE("Fixing externals paths...")
-  fixBuildPaths()
-  logNOTICE("Running externals post install...")
-  checkPlatformAliasLink()
-  return True
-
-
-def installLCGutils(releaseConfig):
-  """
-  DIRAC uses various tools from LCG area. This method install a given
-  lcg version.
-  :param object releaseConfig: the configuration file object (class ReleaseConfig)
-  """
-  if not cliParams.platform:
-    cliParams.platform = getPlatform()
-  if not cliParams.platform:
-    return False
-
-  if cliParams.installSource:
-    tarsURL = cliParams.installSource
-  else:
-    tarsURL = releaseConfig.getTarsLocation('DIRAC')['Value']
-
-  # lcg utils?
-  # LCG utils if required
-  if not releaseConfig:
-    lcgVer = cliParams.lcgVer
-  else:
-    lcgVer = releaseConfig.getLCGVersion(cliParams.lcgVer)
-  if lcgVer:
-    verString = "%s-%s-python%s" % (lcgVer, cliParams.platform, cliParams.pythonVersion)
-    # HACK: try to find a more elegant solution for the lcg bundles location
-    if not downloadAndExtractTarball(tarsURL + "/../lcgBundles", "DIRAC-lcg", verString, False, cache=True):
-      logERROR(
-          "\nThe requested LCG software version %s for the local operating system could not be downloaded." %
-          verString)
-      logERROR("Please, check the availability of the LCG software bindings for you \
-      platform 'DIRAC-lcg-%s' \n in the repository %s/lcgBundles/." %
-               (verString, os.path.dirname(tarsURL)))
-      logERROR(
-          "\nIf you would like to skip the installation of the LCG software, redo the installation with \
-          adding the option --no-lcg-bundle to the command line.")
-      return False
-
-  logNOTICE("Fixing Python Shebang...")
-  fixPythonShebang()
-  return True
-
-
-def createPermanentDirLinks():
-  """ Create links to permanent directories from within the version directory
-  """
-  if cliParams.useVersionsDir:
-    try:
-      # Directories
-      for directory in ['startup', 'runit', 'data', 'work', 'control', 'sbin', 'etc', 'webRoot']:
-        fake = os.path.join(cliParams.targetPath, directory)
-        real = os.path.join(cliParams.basePath, directory)
-        if not os.path.exists(real):
-          os.makedirs(real)
-        if os.path.exists(fake):
-          # Try to reproduce the directory structure to avoid lacking directories
-          fakeDirs = os.listdir(fake)
-          for fd in fakeDirs:
-            if os.path.isdir(os.path.join(fake, fd)):
-              if not os.path.exists(os.path.join(real, fd)):
-                os.makedirs(os.path.join(real, fd))
-          os.rename(fake, fake + '.bak')
-        os.symlink(real, fake)
-
-      # Files
-      for filename in ['bashrc']:
-        fake = os.path.join(cliParams.targetPath, filename)
-        real = os.path.join(cliParams.basePath, filename)
-        os.symlink(real, fake)
-    except Exception as x:
-      logERROR(str(x))
-      return False
-
-  return True
-
-
-def createOldProLinks():
-  """ Create links to permanent directories from within the version directory
-  """
-  proPath = cliParams.targetPath
-  if cliParams.useVersionsDir:
-    oldPath = os.path.join(cliParams.basePath, 'old')
-    proPath = os.path.join(cliParams.basePath, 'pro')
-    try:
-      if os.path.exists(proPath) or os.path.islink(proPath):
-        if os.path.exists(oldPath) or os.path.islink(oldPath):
-          os.unlink(oldPath)
-        os.rename(proPath, oldPath)
-      os.symlink(cliParams.targetPath, proPath)
-    except Exception as x:
-      logERROR(str(x))
-      return False
-
-  return True
-
-
-def createBashrc():
-  """ Create DIRAC environment setting script for the bash shell
-  """
-
-  proPath = cliParams.targetPath
-  # Now create bashrc at basePath
-  try:
-    bashrcFile = os.path.join(cliParams.targetPath, 'bashrc')
-    if cliParams.useVersionsDir:
-      bashrcFile = os.path.join(cliParams.basePath, 'bashrc')
-      proPath = os.path.join(cliParams.basePath, 'pro')
-    logNOTICE('Creating %s' % bashrcFile)
-    if not os.path.exists(bashrcFile):
-      lines = ['# DIRAC bashrc file, used by service and agent run scripts to set environment',
-               'export PYTHONUNBUFFERED=yes',
-               'export PYTHONOPTIMIZE=x']
-      if 'HOME' in os.environ:
-        lines.append('[ -z "$HOME" ] && export HOME=%s' % os.environ['HOME'])
-
-      # Determining where the CAs are...
-      if 'X509_CERT_DIR' in os.environ:
-        certDir = os.environ['X509_CERT_DIR']
-      else:
-        if os.path.isdir('/etc/grid-security/certificates') and \
-           os.listdir('/etc/grid-security/certificates'):
-          # Assuming that, if present, it is not empty, and has correct CAs
-          certDir = '/etc/grid-security/certificates'
-        else:
-          # But this will have to be created at some point (dirac-configure)
-          certDir = '%s/etc/grid-security/certificates' % proPath
-      lines.extend(['# CAs path for SSL verification',
-                    'export X509_CERT_DIR=${X509_CERT_DIR:-%s}' % certDir,
-                    'export SSL_CERT_DIR=${SSL_CERT_DIR:-%s}' % certDir])
-
-      lines.append(
-          'export X509_VOMS_DIR=${X509_VOMS_DIR:-%s}' %
-          os.path.join(
-              proPath,
-              'etc',
-              'grid-security',
-              'vomsdir'))
-      lines.append(
-          'export X509_VOMSES=${X509_VOMSES:-%s}' %
-          os.path.join(
-              proPath,
-              'etc',
-              'grid-security',
-              'vomses'))
-      lines.extend(
-          [
-              '# Some DIRAC locations',
-              '[ -z "$DIRAC" ] && export DIRAC=%s' %
-              proPath,
-              'export DIRACBIN=%s' %
-              os.path.join(
-                  "$DIRAC",
-                  cliParams.platform,
-                  'bin'),
-              'export DIRACSCRIPTS=%s' %
-              os.path.join(
-                  "$DIRAC",
-                  'scripts'),
-              'export DIRACLIB=%s' %
-              os.path.join(
-                  "$DIRAC",
-                  cliParams.platform,
-                  'lib'),
-              'export TERMINFO=%s' %
-              __getTerminfoLocations(
-                  os.path.join(
-                      "$DIRAC",
-                      cliParams.platform,
-                      'share',
-                      'terminfo')),
-              'export RRD_DEFAULT_FONT=%s' %
-              os.path.join(
-                  "$DIRAC",
-                  cliParams.platform,
-                  'share',
-                  'rrdtool',
-                  'fonts',
-                  'DejaVuSansMono-Roman.ttf')])
-
-      lines.extend(['# Prepend the PYTHONPATH, the LD_LIBRARY_PATH, and the DYLD_LIBRARY_PATH'])
-      lines.extend(['( echo $PATH | grep -q $DIRACBIN ) || export PATH=$DIRACBIN:$PATH',
-                    '( echo $PATH | grep -q $DIRACSCRIPTS ) || export PATH=$DIRACSCRIPTS:$PATH',
-                    '( echo $LD_LIBRARY_PATH | grep -q $DIRACLIB ) || \
-                    export LD_LIBRARY_PATH=$DIRACLIB:$LD_LIBRARY_PATH',
-                    '( echo $LD_LIBRARY_PATH | grep -q $DIRACLIB/mysql ) || \
-                    export LD_LIBRARY_PATH=$DIRACLIB/mysql:$LD_LIBRARY_PATH',
-                    '( echo $DYLD_LIBRARY_PATH | grep -q $DIRACLIB ) || \
-                    export DYLD_LIBRARY_PATH=$DIRACLIB:$DYLD_LIBRARY_PATH',
-                    '( echo $DYLD_LIBRARY_PATH | grep -q $DIRACLIB/mysql ) || \
-                    export DYLD_LIBRARY_PATH=$DIRACLIB/mysql:$DYLD_LIBRARY_PATH'])
-
-      lines.extend(['export PYTHONPATH=$DIRAC'])
-
-      lines.extend(['# new OpenSSL version require OPENSSL_CONF to point to some accessible location',
-                    'export OPENSSL_CONF=/tmp'])
-
-      # gfal2 requires some environment variables to be set
-      lines.extend(['# Gfal2 configuration and plugins', 'export GFAL_CONFIG_DIR=%s' %
-                    os.path.join("$DIRAC", cliParams.platform, 'etc/gfal2.d'), 'export  GFAL_PLUGIN_DIR=%s' %
-                    os.path.join("$DIRACLIB", 'gfal2-plugins')])
-      # add DIRACPLAT environment variable for client installations
-      if cliParams.externalsType == 'client':
-        lines.extend(['# DIRAC platform',
-                      '[ -z "$DIRACPLAT" ] && export DIRACPLAT=`$DIRAC/scripts/dirac-platform`'])
-      # Add the lines required for globus-* tools to use IPv6
-      lines.extend(['# IPv6 support',
-                    'export GLOBUS_IO_IPV6=TRUE',
-                    'export GLOBUS_FTP_CLIENT_IPV6=TRUE'])
-      # Add the lines required for ARC CE support
-      lines.extend(['# ARC Computing Element',
-                    'export ARC_PLUGIN_PATH=$DIRACLIB/arc'])
-
-      # Add the lines required for fork support for xrootd
-      lines.extend(['# Fork support for xrootd',
-                    'export XRD_RUNFORKHANDLER=1'])
-
-      # Add the lines required for further env variables requested
-      if cliParams.userEnvVariables:
-        lines.extend(['# User-requested variables'])
-        for envName, envValue in cliParams.userEnvVariables.items():
-          lines.extend(['( echo $%s | grep -q $%s ) || export %s=$%s:$%s' % (
-              envName, envValue,
-              envName, envName, envValue)])
-
-      # Add possible DIRAC environment variables
-      lines.append('')
-      lines.append('# before enabling any of these variables, please see the documentation ')
-      lines.append('# https://dirac.readthedocs.io/en/latest/AdministratorGuide/' +
-                   'ServerInstallations/environment_variable_configuration.html')
-      lines.append('# export DIRAC_DEBUG_DENCODE_CALLSTACK=1')
-      lines.append('# export DIRAC_DEBUG_STOMP=1')
-      lines.append('# export DIRAC_DEPRECATED_FAIL=1')
-      lines.append('# export DIRAC_GFAL_GRIDFTP_SESSION_REUSE=true')
-      lines.append('# export DIRAC_USE_JSON_DECODE=no')
-      lines.append('# export DIRAC_USE_JSON_ENCODE=no')
-      lines.append('# export DIRAC_USE_M2CRYPTO=true')
-      lines.append('# export DIRAC_USE_NEWTHREADPOOL=yes')
-      lines.append('# export DIRAC_NO_CFG=true')
-      lines.append('')
-      f = open(bashrcFile, 'w')
-      f.write('\n'.join(lines))
-      f.close()
-  except Exception as x:
-    logERROR(str(x))
-    return False
-
-  return True
-
-
-def createCshrc():
-  """ Create DIRAC environment setting script for the (t)csh shell
-  """
-  proPath = cliParams.targetPath
-  # Now create cshrc at basePath
-  try:
-    cshrcFile = os.path.join(cliParams.targetPath, 'cshrc')
-    if cliParams.useVersionsDir:
-      cshrcFile = os.path.join(cliParams.basePath, 'cshrc')
-      proPath = os.path.join(cliParams.basePath, 'pro')
-    logNOTICE('Creating %s' % cshrcFile)
-    if not os.path.exists(cshrcFile):
-      lines = ['# DIRAC cshrc file, used by clients to set up the environment',
-               'setenv PYTHONUNBUFFERED yes',
-               'setenv PYTHONOPTIMIZE x']
-
-      # Determining where the CAs are...
-      if 'X509_CERT_DIR' in os.environ:
-        certDir = os.environ['X509_CERT_DIR']
-      else:
-        if os.path.isdir('/etc/grid-security/certificates') and \
-           os.listdir('/etc/grid-security/certificates'):
-          # Assuming that, if present, it is not empty, and has correct CAs
-          certDir = '/etc/grid-security/certificates'
-        else:
-          # But this will have to be created at some point (dirac-configure)
-          certDir = '%s/etc/grid-security/certificates' % proPath
-      lines.extend(['# CAs path for SSL verification',
-                    'setenv X509_CERT_DIR %s' % certDir,
-                    'setenv SSL_CERT_DIR %s' % certDir])
-
-      lines.append(
-          'setenv X509_VOMS_DIR %s' %
-          os.path.join(
-              proPath,
-              'etc',
-              'grid-security',
-              'vomsdir'))
-      lines.append(
-          'setenv X509_VOMSES %s' %
-          os.path.join(
-              proPath,
-              'etc',
-              'grid-security',
-              'vomses'))
-      lines.extend(['# Some DIRAC locations',
-                    '( test $?DIRAC -eq 1 ) || setenv DIRAC %s' % proPath,
-                    'setenv DIRACBIN %s' % os.path.join("$DIRAC", cliParams.platform, 'bin'),
-                    'setenv DIRACSCRIPTS %s' % os.path.join("$DIRAC", 'scripts'),
-                    'setenv DIRACLIB %s' % os.path.join("$DIRAC", cliParams.platform, 'lib'),
-                    'setenv TERMINFO %s' % __getTerminfoLocations(os.path.join("$DIRAC",
-                                                                               cliParams.platform,
-                                                                               'share',
-                                                                               'terminfo'))])
-
-      lines.extend(['# Prepend the PYTHONPATH, the LD_LIBRARY_PATH, and the DYLD_LIBRARY_PATH'])
-
-      lines.extend(['( test $?PATH -eq 1 ) || setenv PATH ""',
-                    '( test $?LD_LIBRARY_PATH -eq 1 ) || setenv LD_LIBRARY_PATH ""',
-                    '( test $?DY_LD_LIBRARY_PATH -eq 1 ) || setenv DYLD_LIBRARY_PATH ""',
-                    '( test $?PYTHONPATH -eq 1 ) || setenv PYTHONPATH ""',
-                    '( echo $PATH | grep -q $DIRACBIN ) || setenv PATH ${DIRACBIN}:$PATH',
-                    '( echo $PATH | grep -q $DIRACSCRIPTS ) || setenv PATH ${DIRACSCRIPTS}:$PATH',
-                    '( echo $LD_LIBRARY_PATH | grep -q $DIRACLIB ) || \
-                    setenv LD_LIBRARY_PATH ${DIRACLIB}:$LD_LIBRARY_PATH',
-                    '( echo $LD_LIBRARY_PATH | grep -q $DIRACLIB/mysql ) || \
-                    setenv LD_LIBRARY_PATH ${DIRACLIB}/mysql:$LD_LIBRARY_PATH',
-                    '( echo $DYLD_LIBRARY_PATH | grep -q $DIRACLIB ) || \
-                    setenv DYLD_LIBRARY_PATH ${DIRACLIB}:$DYLD_LIBRARY_PATH',
-                    '( echo $DYLD_LIBRARY_PATH | grep -q $DIRACLIB/mysql ) || \
-                    setenv DYLD_LIBRARY_PATH ${DIRACLIB}/mysql:$DYLD_LIBRARY_PATH'])
-
-      lines.extend(['setenv PYTHONPATH ${DIRAC}'])
-
-      lines.extend(['# new OpenSSL version require OPENSSL_CONF to point to some accessible location',
-                    'setenv OPENSSL_CONF /tmp'])
-      lines.extend(['# IPv6 support',
-                    'setenv GLOBUS_IO_IPV6 TRUE',
-                    'setenv GLOBUS_FTP_CLIENT_IPV6 TRUE'])
-      # gfal2 requires some environment variables to be set
-      lines.extend(['# Gfal2 configuration and plugins', 'setenv GFAL_CONFIG_DIR %s' %
-                    os.path.join("$DIRAC", cliParams.platform, 'etc/gfal2.d'), 'setenv  GFAL_PLUGIN_DIR %s' %
-                    os.path.join("$DIRACLIB", 'gfal2-plugins')])
-      # add DIRACPLAT environment variable for client installations
-      if cliParams.externalsType == 'client':
-        lines.extend(['# DIRAC platform',
-                      'test $?DIRACPLAT -eq 1 || setenv DIRACPLAT `$DIRAC/scripts/dirac-platform`'])
-      # Add the lines required for ARC CE support
-      lines.extend(['# ARC Computing Element',
-                    'setenv ARC_PLUGIN_PATH $DIRACLIB/arc'])
-
-      # Add the lines required for fork support for xrootd
-      lines.extend(['# Fork support for xrootd',
-                    'setenv XRD_RUNFORKHANDLER 1'])
-
-      # Add the lines required for further env variables requested
-      if cliParams.userEnvVariables:
-        lines.extend(['# User-requested variables'])
-        for envName, envValue in cliParams.userEnvVariables.items():
-          lines.extend(['setenv %s %s' % (envName, envValue)])
-
-      lines.append('')
-      f = open(cshrcFile, 'w')
-      f.write('\n'.join(lines))
-      f.close()
-  except Exception as x:
-    logERROR(str(x))
-    return False
-
-  return True
 
 
 def writeDefaultConfiguration():
@@ -2339,20 +1618,6 @@ def writeDefaultConfiguration():
   except Exception as excp:
     logERROR("Could not write %s: %s" % (filePath, excp))
   logNOTICE("Defaults written to %s" % filePath)
-
-
-def __getTerminfoLocations(defaultLocation=None):
-  """returns the terminfo locations as a colon separated string"""
-
-  terminfoLocations = []
-  if defaultLocation:
-    terminfoLocations = [defaultLocation]
-
-  for termpath in ['/usr/share/terminfo', '/etc/terminfo']:
-    if os.path.exists(termpath):
-      terminfoLocations.append(termpath)
-
-  return ":".join(terminfoLocations)
 
 
 def installDiracOS(releaseConfig):
@@ -2388,9 +1653,6 @@ def createBashrcForDiracOS():
   # Now create bashrc at basePath
   try:
     bashrcFile = os.path.join(cliParams.targetPath, 'bashrc')
-    if cliParams.useVersionsDir:
-      bashrcFile = os.path.join(cliParams.basePath, 'bashrc')
-      proPath = os.path.join(cliParams.basePath, 'pro')
     logNOTICE('Creating %s' % bashrcFile)
     if not os.path.exists(bashrcFile):
       lines = ['# DIRAC bashrc file, used by service and agent run scripts to set environment',
@@ -2431,13 +1693,25 @@ def createBashrcForDiracOS():
               'etc',
               'grid-security',
               'vomses'))
-      lines.extend(
-          [
-              '# Some DIRAC locations',
-              'export DIRACSCRIPTS=%s' %
-              os.path.join(
-                  "$DIRAC",
-                  'scripts')])
+
+      if cliParams.modules:
+        lines.extend(
+            [
+                '# Some DIRAC locations',
+                'export DIRACSCRIPTS=%s' %
+                os.path.join(
+                    "$DIRAC",
+                    'DIRAC',
+                    'src',
+                    'scripts')])
+      else:
+        lines.extend(
+            [
+                '# Some DIRAC locations',
+                'export DIRACSCRIPTS=%s' %
+                os.path.join(
+                    "$DIRAC",
+                    'scripts')])
 
       lines.extend(['# Prepend the PATH and set the PYTHONPATH'])
 
@@ -2448,10 +1722,8 @@ def createBashrcForDiracOS():
       lines.extend(['# new OpenSSL version require OPENSSL_CONF to point to some accessible location',
                     'export OPENSSL_CONF=/tmp'])
 
-      # add DIRACPLAT environment variable for client installations
-      if cliParams.externalsType == 'client':
-        lines.extend(['# DIRAC platform',
-                      '[ -z "$DIRACPLAT" ] && export DIRACPLAT=`$DIRAC/scripts/dirac-platform`'])
+      lines.extend(['# DIRAC platform',
+                    '[ -z "$DIRACPLAT" ] && export DIRACPLAT=`$DIRAC/scripts/dirac-platform`'])
       # Add the lines required for globus-* tools to use IPv6
       lines.extend(['# IPv6 support',
                     'export GLOBUS_IO_IPV6=TRUE',
@@ -2464,20 +1736,6 @@ def createBashrcForDiracOS():
       # Add the lines required for fork support for xrootd
       lines.extend(['# Fork support for xrootd',
                     'export XRD_RUNFORKHANDLER=1'])
-
-      # Add possible DIRAC environment variables
-      lines.append('')
-      lines.append('# before enabling any of these variables, please see the documentation ')
-      lines.append('# https://dirac.readthedocs.io/en/latest/AdministratorGuide/' +
-                   'ServerInstallations/environment_variable_configuration.html')
-      lines.append('# export DIRAC_DEBUG_DENCODE_CALLSTACK=1')
-      lines.append('# export DIRAC_DEBUG_STOMP=1')
-      lines.append('# export DIRAC_DEPRECATED_FAIL=1')
-      lines.append('# export DIRAC_GFAL_GRIDFTP_SESSION_REUSE=true')
-      lines.append('# export DIRAC_USE_JSON_DECODE=no')
-      lines.append('# export DIRAC_USE_JSON_ENCODE=no')
-      lines.append('# export DIRAC_USE_M2CRYPTO=true')
-      lines.append('# export DIRAC_USE_NEWTHREADPOOL=yes')
 
       # Add the lines required for further env variables requested
       if cliParams.userEnvVariables:
@@ -2584,45 +1842,43 @@ if __name__ == "__main__":
       sys.exit(1)
   else:
     releaseConfig = result['Value']
-  if not createPermanentDirLinks():
-    sys.exit(1)
 
-  if not cliParams.externalsOnly:
-    logNOTICE("Discovering modules to install")
-    if releaseConfig:
-      result = releaseConfig.getModulesToInstall(cliParams.release, cliParams.extensions)
-      if not result['OK']:
-        logERROR(result['Message'])
-        sys.exit(1)
-      modsOrder, modsToInstall = result['Value']
-    if cliParams.debug and releaseConfig:
-      logNOTICE("Writing down the releases files")
-      releaseConfig.dumpReleasesToPath()
-    logNOTICE("Installing modules...")
-    for modName in set(modsOrder):
-      tarsURL, modVersion = modsToInstall[modName]
-      if cliParams.installSource and not cliParams.modules:
-        # we install not release version of DIRAC
-        tarsURL = cliParams.installSource
-      if modName in cliParams.modules:
-        sourceURL = cliParams.modules[modName].get('sourceUrl')
-        if 'Version' in cliParams.modules[modName]:
-          modVersion = cliParams.modules[modName]['Version']
-        if not sourceURL:
-          retVal = releaseConfig.getModSource(cliParams.release, modName)
-          if retVal['OK']:
-            tarsURL = retVal['Value'][1]  # this is the git repository url
-            modVersion = cliParams.tag
-        else:
-          tarsURL = sourceURL
-        retVal = checkoutFromGit(modName, tarsURL, modVersion)
-        if not retVal['OK']:
-          logERROR("Cannot checkout %s" % retVal['Message'])
-          sys.exit(1)
+  logNOTICE("Discovering modules to install")
+  if releaseConfig:
+    result = releaseConfig.getModulesToInstall(cliParams.release, cliParams.extensions)
+    if not result['OK']:
+      logERROR(result['Message'])
+      sys.exit(1)
+    modsOrder, modsToInstall = result['Value']
+  if cliParams.debug and releaseConfig:
+    logNOTICE("Writing down the releases files")
+    releaseConfig.dumpReleasesToPath()
+  logNOTICE("Installing modules...")
+  for modName in set(modsOrder):
+    tarsURL, modVersion = modsToInstall[modName]
+    if cliParams.installSource and not cliParams.modules:
+      # we install not release version of DIRAC
+      tarsURL = cliParams.installSource
+    if modName in cliParams.modules:
+      sourceURL = cliParams.modules[modName].get('sourceUrl')
+      if 'Version' in cliParams.modules[modName]:
+        modVersion = cliParams.modules[modName]['Version']
+      if not sourceURL:
+        retVal = releaseConfig.getModSource(cliParams.release, modName)
+        if retVal['OK']:
+          tarsURL = retVal['Value'][1]  # this is the git repository url
+          modVersion = cliParams.tag
       else:
-        logNOTICE("Installing %s:%s" % (modName, modVersion))
-        if not downloadAndExtractTarball(tarsURL, modName, modVersion):
-          sys.exit(1)
+        tarsURL = sourceURL
+      retVal = checkoutFromGit(modName, tarsURL, modVersion)
+      if not retVal['OK']:
+        logERROR("Cannot checkout %s" % retVal['Message'])
+        sys.exit(1)
+    else:
+      logNOTICE("Installing %s:%s" % (modName, modVersion))
+      if not downloadAndExtractTarball(tarsURL, modName, modVersion):
+        sys.exit(1)
+
     logNOTICE("Deploying scripts...")
     ddeLocation = os.path.join(cliParams.targetPath, "DIRAC", "Core",
                                "scripts", "dirac-deploy-scripts.py")
@@ -2646,35 +1902,13 @@ if __name__ == "__main__":
     logNOTICE("Skipping installing DIRAC")
 
   # we install with DIRACOS from v7rX DIRAC release
-  if cliParams.diracOS \
-     or list(releaseConfig.prjRelCFG['DIRAC'])[0][1] not in '0123456789' \
-     or int(list(releaseConfig.prjRelCFG['DIRAC'])[0][1]) > 6:
-    logNOTICE("Installing DIRAC OS %s..." % cliParams.diracOSVersion)
-    if not installDiracOS(releaseConfig):
-      sys.exit(1)
-    if not createBashrcForDiracOS():
-      sys.exit(1)
-  else:
-    logNOTICE("Installing %s externals..." % cliParams.externalsType)
-    if not installExternals(releaseConfig):
-      sys.exit(1)
-    if cliParams.noLcg:
-      logNOTICE("Skipping installation of LCG software...")
-    else:
-      logNOTICE("Installing LCG software...")
-      if not installLCGutils(releaseConfig):
-        sys.exit(1)
-    if not createBashrc():
-      sys.exit(1)
-    if not createCshrc():
-      sys.exit(1)
-  if not createOldProLinks():
+  logNOTICE("Installing DIRAC OS %s..." % cliParams.diracOSVersion)
+  if not installDiracOS(releaseConfig):
     sys.exit(1)
-  runExternalsPostInstall()
+  if not createBashrcForDiracOS():
+    sys.exit(1)
+
   writeDefaultConfiguration()
-  if cliParams.externalsType == "server":
-    fixMySQLScript()
-  installExternalRequirements(cliParams.externalsType)
   if cliParams.createLink:
     createSymbolicLink()
   logNOTICE("%s properly installed" % cliParams.installation)

--- a/Pilot/dirac-install.py
+++ b/Pilot/dirac-install.py
@@ -2380,18 +2380,6 @@ def installDiracOS(releaseConfig):
   return True
 
 
-def installDiracOSPython3(releaseConfig):
-  """
-  Install DIRAC OS for Python 3.
-
-  :param ReleaseConfig releaseConfig: The ReleaseConfig object for configuring the installation
-  """
-  raise NotImplementedError(
-      "Creating a python 3 based installation of DIRAC is not supported by dirac-install.py\n"
-      "See https://github.com/DIRACGrid/DIRAC/#install for details."
-  )
-
-
 def createBashrcForDiracOS():
   """ Create DIRAC environment setting script for the bash shell
   """
@@ -2651,11 +2639,6 @@ if __name__ == "__main__":
       if cliParams.scriptSymlink:
         cmd += ' --symlink'
 
-      # In MacOS /usr/bin/env does not find python in the $PATH, passing binary path
-      # as an argument to the dirac-deploy-scripts
-      if not cliParams.platform:
-        cliParams.platform = getPlatform()
-
       os.system(cmd)
     else:
       logERROR("No dirac-deploy-scripts found. This doesn't look good")
@@ -2667,12 +2650,8 @@ if __name__ == "__main__":
      or list(releaseConfig.prjRelCFG['DIRAC'])[0][1] not in '0123456789' \
      or int(list(releaseConfig.prjRelCFG['DIRAC'])[0][1]) > 6:
     logNOTICE("Installing DIRAC OS %s..." % cliParams.diracOSVersion)
-    if cliParams.pythonVersion.startswith("3"):
-      if not installDiracOSPython3(releaseConfig):
-        sys.exit(1)
-    else:
-      if not installDiracOS(releaseConfig):
-        sys.exit(1)
+    if not installDiracOS(releaseConfig):
+      sys.exit(1)
     if not createBashrcForDiracOS():
       sys.exit(1)
   else:

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -285,7 +285,7 @@ class InstallDIRAC(CommandBase):
       except (IndexError, ValueError):
         continue
 
-    # 5. pip install DIRAC==version
+    # 5. pip install DIRAC[pilot]==version
     # FIXME: also for extensions
 
     if self.pp.modules:
@@ -293,7 +293,7 @@ class InstallDIRAC(CommandBase):
       url, _, branch = self.pp.modules.split(":::")
       # pip install git+https://github.com/fstagni/DIRAC@v7r2-fixes33
       retCode, output = self.executeAndGetOutput(
-          'pip install git+%s@%s' % (url.replace('.git', ''), branch),
+          'pip install git+%s@%s[pilot]' % (url, branch),
           self.pp.installEnv)
       if retCode:
         self.log.error("Could not pip install DIRAC [ERROR %d]" % retCode)
@@ -301,7 +301,7 @@ class InstallDIRAC(CommandBase):
 
     else:
       retCode, output = self.executeAndGetOutput(
-          'pip install DIRAC==%s' % self.pp.releaseVersion,
+          'pip install DIRAC[pilot]==%s' % self.pp.releaseVersion,
           self.pp.installEnv)
       if retCode:
         self.log.error("Could not pip install DIRAC [ERROR %d]" % retCode)

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -248,6 +248,7 @@ class InstallDIRAC(CommandBase):
     """
 
     # 1. Download DIRACOS
+    # curl -O -L https://github.com/DIRACGrid/DIRACOS2/releases/latest/download/DIRACOS-Linux-$(uname -m).sh
     try:
       machine = os.uname().machine  # py3
     except AttributeError:
@@ -285,12 +286,26 @@ class InstallDIRAC(CommandBase):
         continue
 
     # 5. pip install DIRAC==version
-    retCode, output = self.executeAndGetOutput(
-        'pip install DIRAC==%s' % self.pp.releaseVersion,
-        self.pp.installEnv)
-    if retCode:
-      self.log.error("Could not pip install DIRAC [ERROR %d]" % retCode)
-      self.exitWithError(retCode)
+    # FIXME: also for extensions
+
+    if self.pp.modules:
+      # https://github.com/$DIRAC_test_repo/DIRAC.git:::DIRAC:::$DIRAC_test_branch
+      url, _, branch = self.pp.modules.split(":::")
+      # pip install git+https://github.com/fstagni/DIRAC@v7r2-fixes33
+      retCode, output = self.executeAndGetOutput(
+          'pip install git+%s@%s' % (url.replace('.git', ''), branch),
+          self.pp.installEnv)
+      if retCode:
+        self.log.error("Could not pip install DIRAC [ERROR %d]" % retCode)
+        self.exitWithError(retCode)
+
+    else:
+      retCode, output = self.executeAndGetOutput(
+          'pip install DIRAC==%s' % self.pp.releaseVersion,
+          self.pp.installEnv)
+      if retCode:
+        self.log.error("Could not pip install DIRAC [ERROR %d]" % retCode)
+        self.exitWithError(retCode)
 
   def execute(self):
     """ What is called all the time

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -1005,7 +1005,10 @@ class LaunchAgent(CommandBase):
     if self.pp.executeCmd:
       # Execute user command
       self.log.info("Executing user defined command: %s" % self.pp.executeCmd)
-      self.exitWithError(int(os.system("source bashrc; %s" % self.pp.executeCmd) / 256))
+      if self.pp.pythonVersion == '27':
+        self.exitWithError(int(os.system("source bashrc; %s" % self.pp.executeCmd) / 256))
+      else:
+        self.exitWithError(int(os.system("source diracos/diracosrc; %s" % self.pp.executeCmd) / 256))
 
     self.log.info('Starting JobAgent')
     os.environ['PYTHONUNBUFFERED'] = 'yes'
@@ -1105,7 +1108,10 @@ class MultiLaunchAgent(CommandBase):
     if self.pp.executeCmd:
       # Execute user command
       self.log.info("Executing user defined command: %s" % self.pp.executeCmd)
-      self.exitWithError(int(os.system("source bashrc; %s" % self.pp.executeCmd) / 256))
+      if self.pp.pythonVersion == '27':
+        self.exitWithError(int(os.system("source bashrc; %s" % self.pp.executeCmd) / 256))
+      else:
+        self.exitWithError(int(os.system("source diracos/diracosrc; %s" % self.pp.executeCmd) / 256))
 
     self.log.info('Starting JobAgent')
     os.environ['PYTHONUNBUFFERED'] = 'yes'

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -291,9 +291,9 @@ class InstallDIRAC(CommandBase):
     if self.pp.modules:
       # https://github.com/$DIRAC_test_repo/DIRAC.git:::DIRAC:::$DIRAC_test_branch
       url, _, branch = self.pp.modules.split(":::")
-      # pip install git+https://github.com/fstagni/DIRAC@v7r2-fixes33
+      # git+https://github.com/fstagni/DIRAC.git@v7r2-fixes33#egg=DIRAC[pilot]
       retCode, output = self.executeAndGetOutput(
-          'pip install git+%s@%s[pilot]' % (url, branch),
+          'pip install git+%s@%s#egg=DIRAC[pilot]' % (url, branch),
           self.pp.installEnv)
       if retCode:
         self.log.error("Could not pip install DIRAC [ERROR %d]" % retCode)

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -163,16 +163,10 @@ class InstallDIRAC(CommandBase):
     """
 
     for o, v in self.pp.optList:
-      if o in ('-b', '--build'):
-        self.installOpts.append('-b')
-      elif o == '-d' or o == '--debug':
+      if o == '-d' or o == '--debug':
         self.installOpts.append('-d')
       elif o == '-e' or o == '--extraPackages':
         self.installOpts.append('-e "%s"' % v)
-      elif o == '-g' or o == '--grid':
-        self.pp.gridVersion = v
-      elif o == '-p' or o == '--platform':
-        self.pp.platform = v
       elif o == '-u' or o == '--url':
         self.installOpts.append('-u "%s"' % v)
       elif o in ('-P', '--path'):
@@ -180,13 +174,7 @@ class InstallDIRAC(CommandBase):
         self.pp.rootPath = v
       elif o in ('-V', '--installation'):
         self.installOpts.append('-V "%s"' % v)
-      elif o == '-t' or o == '--server':
-        self.installOpts.append('-t "server"')
 
-    if self.pp.gridVersion:
-      self.installOpts.append("-g '%s'" % self.pp.gridVersion)
-    if self.pp.platform:
-      self.installOpts.append('-p "%s"' % self.pp.platform)
     if self.pp.releaseProject:
       self.installOpts.append("-l '%s'" % self.pp.releaseProject)
     if self.pp.modules:

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -36,16 +36,14 @@ from distutils.version import LooseVersion
 try:
   # For Python 3.0 and later
   from http.client import HTTPSConnection
-  from urllib.request import urlopen
 except ImportError:
   # Fall back to Python 2
   from httplib import HTTPSConnection
-  from urllib2 import urlopen
 
 try:
-  from Pilot.pilotTools import CommandBase
+  from Pilot.pilotTools import CommandBase, retrieveUrlTimeout
 except ImportError:
-  from pilotTools import CommandBase
+  from pilotTools import CommandBase, retrieveUrlTimeout
 ############################
 
 
@@ -268,13 +266,12 @@ class InstallDIRAC(CommandBase):
       machine = os.uname()[4]  # py2
 
     # FIXME: we should have a (set of) different location(s)
-    response = urlopen(
-        "https://github.com/DIRACGrid/DIRACOS2/releases/latest/download/DIRACOS-Linux-%s.sh" % machine
-    )
-    code = response.getcode()
-    if code > 200 or code >= 300:
-      self.log.error("Failed to download DIRACOS-Linux-%s.sh [ERROR %d]" % (machine, code))
-      self.exitWithError(code)
+    if not retrieveUrlTimeout(
+        "https://github.com/DIRACGrid/DIRACOS2/releases/latest/download/DIRACOS-Linux-%s.sh" % machine,
+        "DIRACOS-Linux-%s.sh" % machine,
+        self.log
+    ):
+      self.exitWithError(1)
 
     # 2. bash DIRACOS-Linux-$(uname -m).sh
     retCode, _ = self.executeAndGetOutput("bash DIRACOS-Linux-%s.sh" % machine, self.pp.installEnv)

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -475,7 +475,6 @@ class PilotParams(object):
     self.ceType = ""
     self.queueName = ""
     self.gridCEType = ""
-    self.platform = ""
     # maxNumberOfProcessors: the number of
     # processors allocated to the pilot which the pilot can allocate to one payload
     # used to set payloadProcessors unless other limits are reached (like the number of processors on the WN)
@@ -489,7 +488,6 @@ class PilotParams(object):
     self.stopOnApplicationFailure = True
     self.stopAfterFailedMatches = 10
     self.flavour = 'DIRAC'
-    self.gridVersion = ''
     self.pilotReference = ''
     self.releaseVersion = ''
     self.releaseProject = ''
@@ -525,7 +523,6 @@ class PilotParams(object):
     self.cmdOpts = (
         ('', 'requiredTag=', 'extra required tags for resource description'),
         ('a:', 'gridCEType=', 'Grid CE Type (CREAM etc)'),
-        ('b', 'build', 'Force local compilation'),
         ('c', 'cert', 'Use server certificate instead of proxy'),
         ('d', 'debug', 'Set debug flag'),
         ('e:', 'extraPackages=', 'Extra packages to install (comma separated)'),
@@ -534,7 +531,6 @@ class PilotParams(object):
         ('l:', 'project=', 'Project to install'),
         ('n:', 'name=', 'Set <Site> as Site Name'),
         ('o:', 'option=', 'Option=value to add'),
-        ('p:', 'platform=', 'Use <platform> instead of local one'),
         ('m:', 'maxNumberOfProcessors=',
          'specify a max number of processors to use by the payload inside a pilot'),
         ('', 'modules=', 'for installing non-released code (see dirac-install "-m" option documentation)'),
@@ -642,8 +638,6 @@ class PilotParams(object):
         self.wnVO = v
       elif o in ('-V', '--installation'):
         self.installation = v
-      elif o == '-p' or o == '--platform':
-        self.platform = v
       elif o == '-m' or o == '--maxNumberOfProcessors':
         self.maxNumberOfProcessors = int(v)
       elif o == '-D' or o == '--disk':

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -98,7 +98,7 @@ def retrieveUrlTimeout(url, fileName, log, timeout=0):
       expectedBytes = 0
     data = remoteFD.read()
     if fileName:
-      with open(fileName + '-local', "wb") as localFD:
+      with open(fileName, "wb") as localFD:
         localFD.write(data)
     else:
       urlData += data

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -209,14 +209,6 @@ def getCommand(params, commandName, log):
 
       1. <CommandExtension>Commands
       2. pilotCommands
-      3. <Extension>.WorkloadManagementSystem.PilotAgent.<CommandExtension>Commands
-      4. <Extension>.WorkloadManagementSystem.PilotAgent.pilotCommands
-      5. DIRAC.WorkloadManagementSystem.PilotAgent.<CommandExtension>Commands
-      6. DIRAC.WorkloadManagementSystem.PilotAgent.pilotCommands
-
-      Note that commands in 3.-6. can only be used of the the DIRAC installation
-      has been done. DIRAC extensions are taken from -e ( --extraPackages ) option
-      of the pilot script.
   """
   extensions = params.commandExtensions
   modules = [m + 'Commands' for m in extensions + ['pilot']]
@@ -233,23 +225,7 @@ def getCommand(params, commandName, log):
     if commandObject:
       return commandObject(params), module
 
-  if params.diracInstalled:
-    diracExtensions = []
-    for ext in params.extensions:
-      if not ext.endswith('DIRAC'):
-        diracExtensions.append(ext + 'DIRAC')
-      else:
-        diracExtensions.append(ext)
-    diracExtensions += ['DIRAC']
-    ol = ObjectLoader(diracExtensions, log)
-    for module in modules:
-      commandObject, modulePath = ol.loadObject('WorkloadManagementSystem.PilotAgent',
-                                                module,
-                                                commandName)
-      if commandObject:
-        return commandObject(params), modulePath
-
-  # No command could be instantitated
+  # No command could be instantiated
   return None, None
 
 
@@ -522,9 +498,6 @@ class PilotParams(object):
     self.pilotScriptName = ''
     self.genericOption = ''
     self.wnVO = ''  # for binding the resource (WN) to a specific VO
-    # DIRAC client installation environment
-    self.diracInstalled = False
-    self.diracExtensions = []
     # Some commands can define environment necessary to execute subsequent commands
     self.installEnv = os.environ
     # If DIRAC is preinstalled this file will receive the updates of the local configuration

--- a/tests/CI/pilot_ci.sh
+++ b/tests/CI/pilot_ci.sh
@@ -147,8 +147,11 @@ fullPilot(){
   #this should have been created, we source it so that we can continue
   # shellcheck source=/dev/null
   if ! source "${PILOTINSTALLDIR}/bashrc"; then
-    echo "ERROR: cannot source bashrc" >&2
-    exit 1
+    echo "WARN: cannot source bashrc, trying with diracosrc" >&2
+    if ! source "${PILOTINSTALLDIR}/diracos/diracosrc"; then
+      echo "ERROR: cannot source diracosrc" >&2
+      exit 1
+    fi
   fi
 
   echo -e "\n----PATH:${PATH}\n----" | tr ":" "\n"

--- a/tests/CI/utilities.sh
+++ b/tests/CI/utilities.sh
@@ -17,11 +17,11 @@ prepareForPilot(){
   echo '==> [prepareForPilot]'
 
   #get dirac-install.py
-  curl -O -L https://raw.githubusercontent.com/DIRACGrid/management/master/dirac-install.py
-  chmod +x dirac-install.py
+  # curl -O -L https://raw.githubusercontent.com/DIRACGrid/management/master/dirac-install.py
+  # chmod +x dirac-install.py
 
   #get the pilot files from the Pilot
-  for file in PilotLogger.py PilotLoggerTools.py dirac-pilot.py pilotCommands.py pilotTools.py MessageSender.py
+  for file in PilotLogger.py PilotLoggerTools.py dirac-pilot.py pilotCommands.py pilotTools.py MessageSender.py dirac-install.py
   do
     cp "$TESTCODE/Pilot/Pilot/${file}" .
   done

--- a/tests/CI/utilities.sh
+++ b/tests/CI/utilities.sh
@@ -16,15 +16,12 @@ source "$TESTCODE/DIRAC/tests/Jenkins/utilities.sh"
 prepareForPilot(){
   echo '==> [prepareForPilot]'
 
-  #get dirac-install.py
-  # curl -O -L https://raw.githubusercontent.com/DIRACGrid/management/master/dirac-install.py
-  # chmod +x dirac-install.py
-
-  #get the pilot files from the Pilot
+  #get the pilot files from the Pilot, including dirac-install.py
   for file in PilotLogger.py PilotLoggerTools.py dirac-pilot.py pilotCommands.py pilotTools.py MessageSender.py dirac-install.py
   do
     cp "$TESTCODE/Pilot/Pilot/${file}" .
   done
+  chmod +x dirac-install.py
 
   #get possible extensions
   if [[ "$VO" ]]; then


### PR DESCRIPTION
In this PR:
- added function for installing a python3 client
- stop looking for Pilot commands in DIRAC code
- stop supporting older DIRAC versions



- [x] Needs https://github.com/DIRACGrid/DIRAC/pull/5039

todo:
- [x] use `pip install` for non-released code (like the "-m" of dirac-install)
- [x] install also DIRAC extensions, also considering non-released code
- [ ] submitAndMatch test with python3

Tests:

- workflow tests:
- [x] DIRAC, v7r1px (py2)
- [x] DIRAC, v7r2 (py2)
- [x] DIRAC, 7.2 (py3)
- [x] LHCbDIRAC, v10r1px (py2)
- [x] LHCbDIRAC, v10r2-prex (py2)
- [x] LHCbDIRAC, 10.2.0ax (py3)
- submitAndMatch tests
- [x] DIRAC py2
- [x] LHCbDIRAC py2