### PR TITLE
[master] Quote Tags when generating dirac-configure command

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -41,6 +41,11 @@ except ImportError:
     from httplib import HTTPSConnection
 
 try:
+    from shlex import quote
+except ImportError:
+    from pipes import quote
+
+try:
     from Pilot.pilotTools import CommandBase, retrieveUrlTimeout
 except ImportError:
     from pilotTools import CommandBase, retrieveUrlTimeout
@@ -486,7 +491,7 @@ class CheckCECapabilities(CommandBase):
         for queueParamName, queueParamValue in self.pp.queueParameters.items():
             if isinstance(queueParamValue, list):  # for the tags
                 queueParamValue = ','.join([str(qpv).strip() for qpv in queueParamValue])
-            self.cfg.append("-o /LocalSite/%s=%s" % (queueParamName, queueParamValue))
+            self.cfg.append("-o /LocalSite/%s=%s" % (queueParamName, quote(queueParamValue)))
 
         # Pick up all the relevant resource parameters that will be used in the job matching
         if "WholeNode" in resourceDict:


### PR DESCRIPTION
LHCb's htcondor pilots started failing with this error due to the tags not being quoted in the command:
```bash
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `dirac-configure pilot.cfg -o /LocalSite/CEType=HTCondorCE -o /LocalSite/ExtraPilotOptions=-M 3 -o /LocalSite/ExtraSubmitString=periodic_remove =  (JobStatus == 4) && (time() - EnteredCurrentStatus) > ( 24 * 3600)'
```
