### PR TITLE
pilotCommands: purge installEnv before updating values from diracosrc

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -310,8 +310,9 @@ class InstallDIRAC(CommandBase):
             with open("diracos/diracosrc", "a") as diracosrc:
                 diracosrc.write("\n".join(lines))
 
-        # 6. source diracos/diracosrc then add its content to installEnv
+        # 6. source diracos/diracosrc then replace the content in installEnv
         retCode, output = self.executeAndGetOutput('bash -c "source diracos/diracosrc && env"', self.pp.installEnv)
+        self.pp.installEnv = {}
         if retCode:
             self.log.error("Could not parse the diracos/diracosrc file [ERROR %d]" % retCode)
             self.exitWithError(retCode)


### PR DESCRIPTION
pilotCommands: purge installEnv before updating values from diracosrc. Fixes #156 
Otherwise variables unset in diracosrc just remain in installEnv

PS: Not clear to me if this should go to devel or master.