### PR TITLE
fix: correcting ARC pilot references

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -797,9 +797,15 @@ class ConfigureSite(CommandBase):
             )
 
         # ARC case
+        # JOBID does not provide the full url in recent versions of ARC
+        # JOBURL has been introduced recently and should be preferred when present
         if "GRID_GLOBAL_JOBID" in os.environ:
             self.pp.flavour = "ARC"
             pilotRef = os.environ["GRID_GLOBAL_JOBID"]
+
+        if "GRID_GLOBAL_JOBURL" in os.environ:
+            self.pp.flavour = "ARC"
+            pilotRef = os.environ["GRID_GLOBAL_JOBURL"]
 
         # # DIRAC specific
 


### PR DESCRIPTION
We have an issue with ARC pilot references interacting with AREX services.

From what I understand, since ARC6, there is a new environment variable providing the pilot reference, which is `GRID_GLOBAL_JOBURL`: https://source.coderefinery.org/nordugrid/arc/-/merge_requests/1017
`GRID_GLOBAL_JOBID` now provides only the ID of the job and not the full URL like before (with gridftp).

Because of that, pilots set the `PilotReference` attribute to : `<ARCID>` instead of `https://<ARCINSTANCE>:<PORT>/rest/1.0/<ARCID>`, which prevents associations between the pilot and the jobs.

