### PR TITLE
[devel] Remote Pilot Logger to Tornado new JSON format (VO name fix)

### DIFF
--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -792,6 +792,8 @@ class PilotParams(object):
                 self.setup = v
             elif o == "-F" or o == "--pilotCFGFile":
                 self.pilotCFGFile = v
+            elif o == "--wnVO":
+                self.wnVO = v
 
     def __initCommandLine2(self):
         """
@@ -828,8 +830,6 @@ class PilotParams(object):
                 self.executeCmd = v
             elif o in ("-O", "--OwnerDN"):
                 self.userDN = v
-            elif o == "--wnVO":
-                self.wnVO = v
             elif o in ("-V", "--installation"):
                 self.installation = v
             elif o == "-m" or o == "--maxNumberOfProcessors":

--- a/tests/CI/pilot_newSchema.json
+++ b/tests/CI/pilot_newSchema.json
@@ -193,7 +193,7 @@
 				"pilotRepo": "https://github.com/should_not_matter/Pilot.git",
 				"GenericPilotGroup": "dteam_pilot",
 				"GenericPilotDN": "VAR_USERDN",
-				"RemoteLogging": "True",
+				"RemoteLogging": "False",
 				"RemoteLoggerURL": "https://lbvobox70.cern.ch:8443/WorkloadManagement/TornadoPilotLogging",
 				"PilotLogLevel": "DEBUG"
 			}


### PR DESCRIPTION
This is a fix to get a VO name from a` wnVO` command line switch. The switch was moved to __initCommandLine1() from __initCommandLine2() so it is analysed before JSON is parsed. The` VO` name, normally obtained from a proxy or from `DIRAC_PILOT_VO` env variable  is required in `__initJSON2()` to get the release version from a VO-specific JSON section.

Notes:

1. Remote logger was disabled for `dteam` to allow Jenkins tests to run, otherwise the message sender would attempt to contact the DIRAC server which does not have this functionality yet.
2. Furthermore If the remote logger is enabled, the sender fails since no proxy/CA is defined in the test:[(https://github.com/DIRACGrid/Pilot/blob/acd5754e041410e5bd99dd62f5c1c820b0186360/Pilot/pilotTools.py#L472 ](https://github.com/DIRACGrid/Pilot/blob/acd5754e041410e5bd99dd62f5c1c820b0186360/Pilot/pilotTools.py#L472)