### PR TITLE
[master] Set cfg file to modify in CheckCECapabilities

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -572,6 +572,9 @@ class CheckCECapabilities(CommandBase):
             self.pp.reqtags += resourceDict["RequiredTag"]
 
         if self.cfg:
+            if self.pp.localConfigFile:
+                self.cfg.append("-O %s" % self.pp.localConfigFile)  # this file is as output
+
             self.cfg.append("-FDMH")
 
             if self.debugFlag:


### PR DESCRIPTION
@VladimirRomanovsky reported that LHCbDIRAC pilots always try to write to CVMFS:


```log
2023-04-13T06:30:52.815571Z INFO [CheckCECapabilities] Executing command dirac-configure pilot.cfg -o /LocalSite/CEType=ARC -o /LocalSite/SubmissionMode=Direct -o /LocalSite/MaxRAM=131072 -o /LocalSite/MaxTotalJobs=1 -o /LocalSite/VO='lhcb, LHCb' -o /LocalSite/Queue=nordugrid-SLURM-lhcb -o /LocalSite/MaxWaitingJobs=1 -o /LocalSite/SI00=2775 -o /LocalSite/architecture=x86_64 -o /LocalSite/maxCPUTime=6000 -o /LocalSite/wnTmpDir=/tmp -o /LocalSite/OS=ScientificCERNSLC_Carbon_6.9 -o /LocalSite/Pilot=True -FDMH
WARNING: Parsing of '.cfg' files as command line arguments is changing!
          Set the environment variable 'export DIRAC_NO_CFG=1' to pass the file as a positional
          argument (this will become the default).
          To modify the local configuration use '--cfg <configfile>' instead.
Executing: /cvmfs/lhcb.cern.ch/lhcbdirac/versions/v11.0.7-1679490348/Linux-x86_64/bin/dirac-configure pilot.cfg -o /LocalSite/CEType=ARC -o /LocalSite/SubmissionMode=Direct -o /LocalSite/MaxRAM=131072 -o /LocalSite/MaxTotalJobs=1 -o /LocalSite/VO=lhcb, LHCb -o /LocalSite/Queue=nordugrid-SLURM-lhcb -o /LocalSite/MaxWaitingJobs=1 -o /LocalSite/SI00=2775 -o /LocalSite/architecture=x86_64 -o /LocalSite/maxCPUTime=6000 -o /LocalSite/wnTmpDir=/tmp -o /LocalSite/OS=ScientificCERNSLC_Carbon_6.9 -o /LocalSite/Pilot=True -FDMH 
Checking DIRAC installation at "/cvmfs/lhcb.cern.ch/lhcbdirac"
Will update /cvmfs/lhcb.cern.ch/lhcbdirac/etc/dirac.cfg
Can't dump cfg file '/cvmfs/lhcb.cern.ch/lhcbdirac/etc/dirac.cfg'
```

I'm fairly sure this code is intended to modify the `pilot.cfg` file rather than the default `dirac.cfg`. @fstagni What do you think?