### PR TITLE
[devel] Fixing the log finaliser. Fix early logs which were missing. 

### DIFF
--- a/Pilot/dirac-pilot.py
+++ b/Pilot/dirac-pilot.py
@@ -51,8 +51,6 @@ if __name__ == "__main__":
     sys.stdout, buffer = oldstdout, sys.stdout
     bufContent = buffer.getvalue()
     buffer.close()
-    # we would usually have some classic logger content from a wrapper, which we passed in:
-    receivedContent = sys.stdin.read()
     # print the buffer, so we have a "classic' logger back in sync.
     sys.stdout.write(bufContent)
     # now the remote logger.

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -78,13 +78,12 @@ def logFinalizer(func):
             self.log.info(
                 "Flushing the remote logger buffer for pilot on sys.exit(): %s (exit code:%s)" % (pRef, str(exCode))
             )
-            raise
-        finally:
+            self.log.buffer.flush()  # flush the buffer unconditionally (on sys.exit() and return).
             try:
-                self.log.buffer.flush()  # flush the buffer unconditionally (on sys.exit() and return).
                 sendMessage(self.log.url, self.log.pilotUUID, "finaliseLogs", {"retCode": str(exCode)})
             except Exception as exc:
                 self.log.error("Remote logger couldn't be finalised %s " % str(exc))
+            raise
 
     return wrapper
 


### PR DESCRIPTION
2 fixes:

- include early logs collected up to the point when a remote logger is enabled
- fix a finaliser: it was called by mistake at the end of each command 