### PR TITLE
Fix MAMBA_EXTRACT_THREADS environment

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -292,7 +292,7 @@ class InstallDIRAC(CommandBase):
         # default to limit the resources used during installation to what the pilot owns
         installEnv = {
             # see https://github.com/DIRACGrid/Pilot/issues/189
-            "MAMBA_EXTRACT_THREADS": self.pp.maxNumberOfProcessors or 1,
+            "MAMBA_EXTRACT_THREADS": str(self.pp.maxNumberOfProcessors or 1),
         }
         installEnv.update(self.pp.installEnv)
 


### PR DESCRIPTION
The recent PR #190 resulted in the following errors in the running pilots:

```
INFO [InstallDIRAC] Executing command bash /cvmfs/dirac.egi.eu/installSource/DIRACOS-Linux-x86_64.sh 2>&1
Traceback (most recent call last):
  File "dirac-pilot.py", line 89, in <module>
    command.execute()
  File "/sps/lhcb/atsareg/test/pilot/DIRAC_fCOI67pilot/pilotCommands.py", line 73, in wrapper
    return func(self)
  File "/sps/lhcb/atsareg/test/pilot/DIRAC_fCOI67pilot/pilotCommands.py", line 415, in execute
    self._installDIRACpy3()
  File "/sps/lhcb/atsareg/test/pilot/DIRAC_fCOI67pilot/pilotCommands.py", line 314, in _installDIRACpy3
    "bash /cvmfs/dirac.egi.eu/installSource/%s 2>&1" % installerName, installEnv
  File "/sps/lhcb/atsareg/test/pilot/DIRAC_fCOI67pilot/pilotTools.py", line 531, in executeAndGetOutput
    "%s" % cmd, shell=True, env=environDict, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=False
  File "/usr/lib64/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/usr/lib64/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
TypeError: execve() arg 3 contains a non-string value
```
