### PR TITLE
devel: pass tags to the Pilot config only once

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -740,23 +740,21 @@ class CheckCECapabilities(CommandBase):
             self.log.error("The pilot command output is not json compatible.")
             self.exitWithError(1)
 
-        self.pp.queueParameters = resourceDict
-        for queueParamName, queueParamValue in self.pp.queueParameters.items():
-            if isinstance(queueParamValue, list):  # for the tags
-                queueParamValue = ",".join([str(qpv).strip() for qpv in queueParamValue])
-            self.cfg.append("-o /LocalSite/%s=%s" % (queueParamName, quote(queueParamValue)))
-
         # Pick up all the relevant resource parameters that will be used in the job matching
         if "WholeNode" in resourceDict:
             self.pp.tags.append("WholeNode")
 
         # Tags must be added to already defined tags if any
-        if resourceDict.get("Tag"):
-            self.pp.tags += resourceDict["Tag"]
+        self.pp.tags += resourceDict.pop("Tag", [])
 
         # RequiredTags are like Tags.
-        if resourceDict.get("RequiredTag"):
-            self.pp.reqtags += resourceDict["RequiredTag"]
+        self.pp.reqtags += resourceDict.pop("RequiredTag", [])
+
+        self.pp.queueParameters = resourceDict
+        for queueParamName, queueParamValue in self.pp.queueParameters.items():
+            if isinstance(queueParamValue, list):  # for the tags
+                queueParamValue = ",".join([str(qpv).strip() for qpv in queueParamValue])
+            self.cfg.append("-o /LocalSite/%s=%s" % (queueParamName, quote(queueParamValue)))
 
         if self.cfg:
             if self.pp.localConfigFile:


### PR DESCRIPTION
Aims at "solving" https://github.com/DIRACGrid/Pilot/issues/197

Currently:
- `tags`/`reqtags` are present in two different locations in the configuration: 
  - `/LocalSite`: can contain many times the same tags
  - `/Resources/Computing/CEDefaults`: tags are "filtered" such as duplicates are removed

In this PR:
- `tags`/`reqtags` are only present in `/Resources/Computing/CEDefaults`