### PR TITLE
[devel] add a pathelement to be searched for in pilot.json

### DIFF
--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -1114,6 +1114,7 @@ class PilotParams(object):
         vo = self.__getVO()
         paths = [
             "/Defaults/Pilot",
+            "/%s/Pilot" % vo,
             "/%s/Pilot" % self.setup,
             "/%s/Defaults/Pilot" % vo,
             "/%s/%s/Pilot" % (vo, self.setup),


### PR DESCRIPTION
Add a `/<voname>/Pilot` path element to be searched  for when pilot.json is parsed.