### PR TITLE
test: adding integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -163,7 +163,7 @@ jobs:
           sed -i "s/VAR_JENKINS_SITE/DIRAC.Jenkins.ch/g" pilot.json
           sed -i "s/VAR_JENKINS_CE/jenkins-lhcb.cern.ch/g" pilot.json
           sed -i "s/VAR_JENKINS_QUEUE/jenkins-queue_not_important/g" pilot.json
-          sed -i "s/VAR_DIRAC_VERSION//g" pilot.json
+          sed -i "s/VAR_DIRAC_VERSION/v11.0.20/g" pilot.json
           sed -i "s#VAR_CS#https://lbcertifdirac70.cern.ch:9135/Configuration/Server#g" pilot.json
           sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
           sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -168,3 +168,41 @@ jobs:
           sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
           sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
           python dirac-pilot.py -M 1 -S DIRAC-Certification -N jenkins-lhcb.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch -e LHCb -l LHCb -E LHCbPilot --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
+
+  ext-lhcb_integration_dirac_installer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cvmfs-contrib/github-action-cvmfs@v3
+
+      - name: Test CernVM-FS
+        run: ls /cvmfs/lhcb.cern.ch
+
+      - name: Retrieve the secret and decode it to a file
+        env:
+          HOSTCERT_BASE64: ${{ secrets.HOSTCERT_BASE64 }}
+          HOSTKEY_BASE64: ${{ secrets.HOSTKEY_BASE64 }}
+        run: |
+          cd Pilot
+          mkdir -p etc/grid-security/vomses
+          mkdir -p etc/grid-security/vomsdir
+          mkdir -p etc/grid-security/certificates
+          echo "$HOSTCERT_BASE64" | base64 --decode > etc/grid-security/hostcert.pem
+          echo "$HOSTKEY_BASE64" | base64 --decode > etc/grid-security/hostkey.pem
+          chmod 440 etc/grid-security/hostcert.pem
+          chmod 400 etc/grid-security/hostkey.pem
+      - name: tests
+        run: |
+          cd Pilot
+          export VO_LHCB_SW_DIR=${GITHUB_WORKSPACE}/Pilot
+          curl https://lhcbdirac.s3.cern.ch/Pilot3/LHCbPilotCommands.py -o LHCbPilotCommands.py
+          cp ../tests/CI/pilot_oldSchema.json pilot.json
+          sed -i "s/VAR_JENKINS_SITE/DIRAC.Jenkins.ch/g" pilot.json
+          sed -i "s/VAR_JENKINS_CE/jenkins-lhcb.cern.ch/g" pilot.json
+          sed -i "s/VAR_JENKINS_QUEUE/jenkins-queue_not_important/g" pilot.json
+          sed -i "s/VAR_DIRAC_VERSION/v11.0.20/g" pilot.json
+          sed -i "s#VAR_CS#https://lbcertifdirac70.cern.ch:9135/Configuration/Server#g" pilot.json
+          sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
+          sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
+          python dirac-pilot.py -M 1 -S DIRAC-Certification -N jenkins-lhcb_d.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch -e LHCb -l LHCb -E LHCbPilot --preinstalledEnvPrefix=/cvmfs/lhcb.cern.ch/lhcbdirac/ --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,6 @@
 name: integration
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   integration:
@@ -27,10 +27,11 @@ jobs:
         run: |
           cd Pilot
           mkdir -p etc/grid-security
-          echo $HOSTCERT_BASE64 | base64 --decode > etc/grid-security/hostcert.pem
-          echo $HOSTKEY_BASE64 | base64 --decode > etc/grid-security/hostkey.pem
+          echo "$HOSTCERT_BASE64" | base64 --decode > etc/grid-security/hostcert.pem
+          echo "$HOSTKEY_BASE64" | base64 --decode > etc/grid-security/hostkey.pem
           chmod 440 etc/grid-security/hostcert.pem
           chmod 400 etc/grid-security/hostkey.pem
+          ls -l etc/grid-security
       - name: tests
         run: |
           cd Pilot
@@ -45,12 +46,19 @@ jobs:
           python dirac-pilot.py --modules https://github.com/DIRACGrid/DIRAC.git:::DIRAC:::${{ matrix.dirac_version }} -M 1 -S DIRAC-Certification -N jenkins.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
           cat pilot.cfg
 
+
   matching:
     runs-on: ubuntu-latest
 
-    container: python:3.9.17-slim
+    strategy:
+      matrix:
+        python: 
+          - 2.7.18
+          - 3.6.15
+          - 3.9.17
 
-
+    container: python:${{ matrix.python }}-slim
+    
     steps:
       - uses: actions/checkout@v4
       - name: Retrieve the secret and decode it to a file
@@ -60,8 +68,8 @@ jobs:
         run: |
           cd Pilot
           mkdir -p etc/grid-security
-          echo $HOSTCERT_BASE64 | base64 --decode > etc/grid-security/hostcert.pem
-          echo $HOSTKEY_BASE64 | base64 --decode > etc/grid-security/hostkey.pem
+          echo "$HOSTCERT_BASE64" | base64 --decode > etc/grid-security/hostcert.pem
+          echo "$HOSTKEY_BASE64" | base64 --decode > etc/grid-security/hostkey.pem
           chmod 440 etc/grid-security/hostcert.pem
           chmod 400 etc/grid-security/hostkey.pem
       - name: tests
@@ -90,15 +98,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: cvmfs-contrib/github-action-cvmfs@v3
 
-      - name: add cvmfs
-        run: |
-          wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
-          sudo dpkg -i cvmfs-release-latest_all.deb
-          rm -f cvmfs-release-latest_all.deb
-          sudo apt-get update
-          sudo apt-get install cvmfs
-          sudo cvmfs_config setup
+      - name: Test CernVM-FS
+        run: ls /cvmfs/lhcb.cern.ch
+
       - name: Retrieve the secret and decode it to a file
         env:
           HOSTCERT_BASE64: ${{ secrets.HOSTCERT_BASE64 }}
@@ -108,25 +112,22 @@ jobs:
           mkdir -p etc/grid-security/vomses
           mkdir -p etc/grid-security/vomsdir
           mkdir -p etc/grid-security/certificates
-          echo $HOSTCERT_BASE64 | base64 --decode > etc/grid-security/hostcert.pem
-          echo $HOSTKEY_BASE64 | base64 --decode > etc/grid-security/hostkey.pem
+          echo "$HOSTCERT_BASE64" | base64 --decode > etc/grid-security/hostcert.pem
+          echo "$HOSTKEY_BASE64" | base64 --decode > etc/grid-security/hostkey.pem
           chmod 440 etc/grid-security/hostcert.pem
           chmod 400 etc/grid-security/hostkey.pem
       - name: tests
         run: |
           cd Pilot
           export VO_LHCB_SW_DIR=${GITHUB_WORKSPACE}/Pilot
-          echo $VO_LHCB_SW_DIR
           curl https://lhcbdirac.s3.cern.ch/Pilot3/LHCbPilotCommands.py -o LHCbPilotCommands.py
           cp ../tests/CI/pilot_oldSchema.json pilot.json
           sed -i "s/VAR_JENKINS_SITE/DIRAC.Jenkins.ch/g" pilot.json
           sed -i "s/VAR_JENKINS_CE/jenkins-lhcb.cern.ch/g" pilot.json
           sed -i "s/VAR_JENKINS_QUEUE/jenkins-queue_not_important/g" pilot.json
-          sed -i "s/VAR_DIRAC_VERSION/master/g" pilot.json
+          sed -i "s/VAR_DIRAC_VERSION//g" pilot.json
           sed -i "s#VAR_CS#https://lbcertifdirac70.cern.ch:9135/Configuration/Server#g" pilot.json
           sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
           sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
-          ls -al
-          python dirac-pilot.py --modules https://gitlab.cern.ch/lhcb-dirac/LHCbDIRAC.git:::LHCbDIRAC:::master -M 1 -S DIRAC-Certification -N jenkins-lhcb.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch -e LHCb -l LHCb -E LHCbPilot --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
-          cat pilot.cfg
-    
+          echo $SHELL
+          python dirac-pilot.py -M 1 -S DIRAC-Certification -N jenkins-lhcb.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch -e LHCb -l LHCb -E LHCbPilot --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,46 @@
+name: integration
+
+on: [push, pull_request]
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python: 
+          - 2.7.18
+          - 3.6.15
+          - 3.9.17
+        dirac_version:
+          - rel-v8r0
+          - integration
+
+    container: python:${{ matrix.python }}-slim
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Retrieve the secret and decode it to a file
+        env:
+          HOSTCERT_BASE64: ${{ secrets.HOSTCERT_BASE64 }}
+          HOSTKEY_BASE64: ${{ secrets.HOSTKEY_BASE64 }}
+        run: |
+          cd Pilot
+          mkdir -p etc/grid-security
+          echo $HOSTCERT_BASE64 | base64 --decode > etc/grid-security/hostcert.pem
+          echo $HOSTKEY_BASE64 | base64 --decode > etc/grid-security/hostkey.pem
+          chmod 440 etc/grid-security/hostcert.pem
+          chmod 400 etc/grid-security/hostkey.pem
+      - name: tests
+        run: |
+          cd Pilot
+          cp ../tests/CI/pilot_oldSchema.json pilot.json
+          sed -i "s/VAR_JENKINS_SITE/DIRAC.Jenkins.ch/g" pilot.json
+          sed -i "s/VAR_JENKINS_CE/jenkins.cern.ch/g" pilot.json
+          sed -i "s/VAR_JENKINS_QUEUE/jenkins-queue_not_important/g" pilot.json
+          sed -i "s/VAR_DIRAC_VERSION/${{ matrix.dirac_version }}/g" pilot.json
+          sed -i "s#VAR_CS#https://lbcertifdirac70.cern.ch:9135/Configuration/Server#g" pilot.json
+          sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
+          sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
+          python dirac-pilot.py --modules https://github.com/DIRACGrid/DIRAC.git:::DIRAC:::${{ matrix.dirac_version }} -M 1 -S DIRAC-Certification -N jenkins.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
+          cat pilot.cfg

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,6 @@ jobs:
           sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
           sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
           python dirac-pilot.py --modules https://github.com/DIRACGrid/DIRAC.git:::DIRAC:::${{ matrix.dirac_version }} -M 1 -S DIRAC-Certification -N jenkins.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
-          cat pilot.cfg
 
 
   integration-cvmfs:
@@ -83,7 +82,6 @@ jobs:
           sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
           sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
           python dirac-pilot.py -M 1 -S DIRAC-Certification -N jenkins.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch --preinstalledEnvPrefix=/cvmfs/dirac.egi.eu/dirac --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
-          cat pilot.cfg
 
 
   matching:
@@ -123,6 +121,45 @@ jobs:
           sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
           sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
           python dirac-pilot.py --modules https://github.com/DIRACGrid/DIRAC.git:::DIRAC:::integration -M 1 -S DIRAC-Certification -N jenkins-full.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch --wnVO=dteam --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
+
+
+  integration-cvmfs_matching:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cvmfs-contrib/github-action-cvmfs@v3
+
+      - name: Test CernVM-FS
+        run: ls /cvmfs/dirac.egi.eu
+
+      - name: Retrieve the secret and decode it to a file
+        env:
+          HOSTCERT_BASE64: ${{ secrets.HOSTCERT_BASE64 }}
+          HOSTKEY_BASE64: ${{ secrets.HOSTKEY_BASE64 }}
+        run: |
+          cd Pilot
+          mkdir -p etc/grid-security
+          echo "$HOSTCERT_BASE64" | base64 --decode > etc/grid-security/hostcert.pem
+          echo "$HOSTKEY_BASE64" | base64 --decode > etc/grid-security/hostkey.pem
+          chmod 440 etc/grid-security/hostcert.pem
+          chmod 400 etc/grid-security/hostkey.pem
+      - name: tests
+        env:
+          X509_CERT_DIR: /cvmfs/grid.cern.ch/etc/grid-security/certificates
+          X509_VOMS_DIR: /cvmfs/grid.cern.ch/etc/grid-security/vomsdir
+          DIRAC_VOMSES: /cvmfs/grid.cern.ch/etc/grid-security/vomses
+        run: |
+          cd Pilot
+          cp ../tests/CI/pilot_oldSchema.json pilot.json
+          sed -i "s/VAR_JENKINS_SITE/DIRAC.Jenkins.ch/g" pilot.json
+          sed -i "s/VAR_JENKINS_CE/jenkins-full.cern.ch/g" pilot.json
+          sed -i "s/VAR_JENKINS_QUEUE/jenkins-queue_not_important/g" pilot.json
+          sed -i "s/VAR_DIRAC_VERSION/v8.1.0a16/g" pilot.json
+          sed -i "s#VAR_CS#https://lbcertifdirac70.cern.ch:9135/Configuration/Server#g" pilot.json
+          sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
+          sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
+          python dirac-pilot.py -M 1 -S DIRAC-Certification -N jenkins-full.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch --preinstalledEnvPrefix=/cvmfs/dirac.egi.eu/dirac --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
 
 
   ##################################

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,6 @@ jobs:
           echo "$HOSTKEY_BASE64" | base64 --decode > etc/grid-security/hostkey.pem
           chmod 440 etc/grid-security/hostcert.pem
           chmod 400 etc/grid-security/hostkey.pem
-          ls -l etc/grid-security
       - name: tests
         run: |
           cd Pilot
@@ -68,8 +67,11 @@ jobs:
           echo "$HOSTKEY_BASE64" | base64 --decode > etc/grid-security/hostkey.pem
           chmod 440 etc/grid-security/hostcert.pem
           chmod 400 etc/grid-security/hostkey.pem
-          ls -l etc/grid-security
       - name: tests
+        env:
+          X509_CERT_DIR: /cvmfs/grid.cern.ch/etc/grid-security/certificates
+          X509_VOMS_DIR: /cvmfs/grid.cern.ch/etc/grid-security/vomsdir
+          DIRAC_VOMSES: /cvmfs/grid.cern.ch/etc/grid-security/vomses
         run: |
           cd Pilot
           cp ../tests/CI/pilot_oldSchema.json pilot.json
@@ -82,7 +84,6 @@ jobs:
           sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
           python dirac-pilot.py -M 1 -S DIRAC-Certification -N jenkins.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch --preinstalledEnvPrefix=/cvmfs/dirac.egi.eu/dirac --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
           cat pilot.cfg
-
 
 
   matching:
@@ -155,6 +156,10 @@ jobs:
           chmod 440 etc/grid-security/hostcert.pem
           chmod 400 etc/grid-security/hostkey.pem
       - name: tests
+        env:
+          X509_CERT_DIR: /cvmfs/lhcb.cern.ch/etc/grid-security/certificates
+          X509_VOMS_DIR: /cvmfs/lhcb.cern.ch/etc/grid-security/vomsdir
+          DIRAC_VOMSES: /cvmfs/lhcb.cern.ch/etc/grid-security/vomses
         run: |
           cd Pilot
           export VO_LHCB_SW_DIR=${GITHUB_WORKSPACE}/Pilot
@@ -193,6 +198,10 @@ jobs:
           chmod 440 etc/grid-security/hostcert.pem
           chmod 400 etc/grid-security/hostkey.pem
       - name: tests
+        env:
+          X509_CERT_DIR: /cvmfs/lhcb.cern.ch/etc/grid-security/certificates
+          X509_VOMS_DIR: /cvmfs/lhcb.cern.ch/etc/grid-security/vomsdir
+          DIRAC_VOMSES: /cvmfs/lhcb.cern.ch/etc/grid-security/vomses
         run: |
           cd Pilot
           export VO_LHCB_SW_DIR=${GITHUB_WORKSPACE}/Pilot
@@ -205,4 +214,4 @@ jobs:
           sed -i "s#VAR_CS#https://lbcertifdirac70.cern.ch:9135/Configuration/Server#g" pilot.json
           sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
           sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
-          python dirac-pilot.py -M 1 -S DIRAC-Certification -N jenkins-lhcb_d.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch -e LHCb -l LHCb -E LHCbPilot --preinstalledEnvPrefix=/cvmfs/lhcb.cern.ch/lhcbdirac/ --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
+          python dirac-pilot.py -M 1 -S DIRAC-Certification -N jenkins-lhcb-d.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch -e LHCb -l LHCb -E LHCbPilot --preinstalledEnvPrefix=/cvmfs/lhcb.cern.ch/lhcbdirac/ --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,3 +44,89 @@ jobs:
           sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
           python dirac-pilot.py --modules https://github.com/DIRACGrid/DIRAC.git:::DIRAC:::${{ matrix.dirac_version }} -M 1 -S DIRAC-Certification -N jenkins.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
           cat pilot.cfg
+
+  matching:
+    runs-on: ubuntu-latest
+
+    container: python:3.9.17-slim
+
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Retrieve the secret and decode it to a file
+        env:
+          HOSTCERT_BASE64: ${{ secrets.HOSTCERT_BASE64 }}
+          HOSTKEY_BASE64: ${{ secrets.HOSTKEY_BASE64 }}
+        run: |
+          cd Pilot
+          mkdir -p etc/grid-security
+          echo $HOSTCERT_BASE64 | base64 --decode > etc/grid-security/hostcert.pem
+          echo $HOSTKEY_BASE64 | base64 --decode > etc/grid-security/hostkey.pem
+          chmod 440 etc/grid-security/hostcert.pem
+          chmod 400 etc/grid-security/hostkey.pem
+      - name: tests
+        run: |
+          cd Pilot
+          cp ../tests/CI/pilot_oldSchema.json pilot.json
+          sed -i "s/VAR_JENKINS_SITE/DIRAC.Jenkins.ch/g" pilot.json
+          sed -i "s/VAR_JENKINS_CE/jenkins-full.cern.ch/g" pilot.json
+          sed -i "s/VAR_JENKINS_QUEUE/jenkins-queue_not_important/g" pilot.json
+          sed -i "s/VAR_DIRAC_VERSION/integration/g" pilot.json
+          sed -i "s#VAR_CS#https://lbcertifdirac70.cern.ch:9135/Configuration/Server#g" pilot.json
+          sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
+          sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
+          python dirac-pilot.py --modules https://github.com/DIRACGrid/DIRAC.git:::DIRAC:::integration -M 1 -S DIRAC-Certification -N jenkins-full.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch --wnVO=dteam --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
+
+
+  ##################################
+  ### # extensions tests
+  ##################################
+
+  ##################################
+  #### LHCb
+
+  ext-lhcb_integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: add cvmfs
+        run: |
+          wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+          sudo dpkg -i cvmfs-release-latest_all.deb
+          rm -f cvmfs-release-latest_all.deb
+          sudo apt-get update
+          sudo apt-get install cvmfs
+          sudo cvmfs_config setup
+      - name: Retrieve the secret and decode it to a file
+        env:
+          HOSTCERT_BASE64: ${{ secrets.HOSTCERT_BASE64 }}
+          HOSTKEY_BASE64: ${{ secrets.HOSTKEY_BASE64 }}
+        run: |
+          cd Pilot
+          mkdir -p etc/grid-security/vomses
+          mkdir -p etc/grid-security/vomsdir
+          mkdir -p etc/grid-security/certificates
+          echo $HOSTCERT_BASE64 | base64 --decode > etc/grid-security/hostcert.pem
+          echo $HOSTKEY_BASE64 | base64 --decode > etc/grid-security/hostkey.pem
+          chmod 440 etc/grid-security/hostcert.pem
+          chmod 400 etc/grid-security/hostkey.pem
+      - name: tests
+        run: |
+          cd Pilot
+          export VO_LHCB_SW_DIR=${GITHUB_WORKSPACE}/Pilot
+          echo $VO_LHCB_SW_DIR
+          curl https://lhcbdirac.s3.cern.ch/Pilot3/LHCbPilotCommands.py -o LHCbPilotCommands.py
+          cp ../tests/CI/pilot_oldSchema.json pilot.json
+          sed -i "s/VAR_JENKINS_SITE/DIRAC.Jenkins.ch/g" pilot.json
+          sed -i "s/VAR_JENKINS_CE/jenkins-lhcb.cern.ch/g" pilot.json
+          sed -i "s/VAR_JENKINS_QUEUE/jenkins-queue_not_important/g" pilot.json
+          sed -i "s/VAR_DIRAC_VERSION/master/g" pilot.json
+          sed -i "s#VAR_CS#https://lbcertifdirac70.cern.ch:9135/Configuration/Server#g" pilot.json
+          sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
+          sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
+          ls -al
+          python dirac-pilot.py --modules https://gitlab.cern.ch/lhcb-dirac/LHCbDIRAC.git:::LHCbDIRAC:::master -M 1 -S DIRAC-Certification -N jenkins-lhcb.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch -e LHCb -l LHCb -E LHCbPilot --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
+          cat pilot.cfg
+    

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,7 @@ name: integration
 on: [push]
 
 jobs:
-  integration:
+  integration-local_install:
     runs-on: ubuntu-latest
 
     strategy:
@@ -45,6 +45,44 @@ jobs:
           sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
           python dirac-pilot.py --modules https://github.com/DIRACGrid/DIRAC.git:::DIRAC:::${{ matrix.dirac_version }} -M 1 -S DIRAC-Certification -N jenkins.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
           cat pilot.cfg
+
+
+  integration-cvmfs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cvmfs-contrib/github-action-cvmfs@v3
+
+      - name: Test CernVM-FS
+        run: ls /cvmfs/dirac.egi.eu
+
+      - name: Retrieve the secret and decode it to a file
+        env:
+          HOSTCERT_BASE64: ${{ secrets.HOSTCERT_BASE64 }}
+          HOSTKEY_BASE64: ${{ secrets.HOSTKEY_BASE64 }}
+        run: |
+          cd Pilot
+          mkdir -p etc/grid-security
+          echo "$HOSTCERT_BASE64" | base64 --decode > etc/grid-security/hostcert.pem
+          echo "$HOSTKEY_BASE64" | base64 --decode > etc/grid-security/hostkey.pem
+          chmod 440 etc/grid-security/hostcert.pem
+          chmod 400 etc/grid-security/hostkey.pem
+          ls -l etc/grid-security
+      - name: tests
+        run: |
+          cd Pilot
+          cp ../tests/CI/pilot_oldSchema.json pilot.json
+          sed -i "s/VAR_JENKINS_SITE/DIRAC.Jenkins.ch/g" pilot.json
+          sed -i "s/VAR_JENKINS_CE/jenkins.cern.ch/g" pilot.json
+          sed -i "s/VAR_JENKINS_QUEUE/jenkins-queue_not_important/g" pilot.json
+          sed -i "s/VAR_DIRAC_VERSION/v8.1.0a16/g" pilot.json
+          sed -i "s#VAR_CS#https://lbcertifdirac70.cern.ch:9135/Configuration/Server#g" pilot.json
+          sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
+          sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
+          python dirac-pilot.py -M 1 -S DIRAC-Certification -N jenkins.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch --preinstalledEnvPrefix=/cvmfs/dirac.egi.eu/dirac --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug
+          cat pilot.cfg
+
 
 
   matching:
@@ -129,5 +167,4 @@ jobs:
           sed -i "s#VAR_CS#https://lbcertifdirac70.cern.ch:9135/Configuration/Server#g" pilot.json
           sed -i "s#VAR_USERDN#/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=alboyer/CN=819281/CN=Alexandre Franck Boyer#g" pilot.json
           sed -i "s#VAR_USERDN_GRIDPP#${DIRACUSERDN_GRIDPP}#g" pilot.json
-          echo $SHELL
           python dirac-pilot.py -M 1 -S DIRAC-Certification -N jenkins-lhcb.cern.ch -Q jenkins-queue_not_important -n DIRAC.Jenkins.ch -e LHCb -l LHCb -E LHCbPilot --cert --certLocation=${GITHUB_WORKSPACE}/Pilot/etc/grid-security --debug

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -302,11 +302,16 @@ class InstallDIRAC(CommandBase):
     def _getPreinstalledEnvScript(self):
         """ Get preinstalled environment script if any """
 
+        self.log.debug("self.pp.preinstalledEnv = %s" % self.pp.preinstalledEnv)
+        self.log.debug("self.pp.preinstalledEnvPrefix = %s" % self.pp.preinstalledEnvPrefix)
+        
         preinstalledEnvScript = self.pp.preinstalledEnv
         if not preinstalledEnvScript and self.pp.preinstalledEnvPrefix:
             version = self.pp.releaseVersion or "pro"
             arch = platform.system() + "-" + platform.machine()
             preinstalledEnvScript = os.path.join(self.pp.preinstalledEnvPrefix, version, arch, "diracosrc")
+
+        self.log.debug("preinstalledEnvScript = %s" % preinstalledEnvScript)
 
         if preinstalledEnvScript:
             self.log.info("Evaluating env script %s" % preinstalledEnvScript)

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -808,6 +808,10 @@ class PilotParams(object):
         self.modules = ""  # see dirac-install "-m" option documentation
         self.userEnvVariables = ""  # see dirac-install "--userEnvVariables" option documentation
         self.pipInstallOptions = ""
+        self.CVMFS_locations = [
+            "/cvmfs/grid.cern.ch",
+            "/cvmfs/dirac.egi.eu",
+        ]
 
         # Parameters that can be determined at runtime only
         self.queueParameters = {}  # from CE description

--- a/tests/CI/pilot_newSchema.json
+++ b/tests/CI/pilot_newSchema.json
@@ -77,7 +77,7 @@
 		"jenkins-lhcb-d.cern.ch": {
 			"Site": "VAR_JENKINS_SITE",
 			"GridCEType": "LHCbD"
-		  }	  
+		}	  
 	},
 	"GenericPilotDNs": [],
 	"Defaults": {

--- a/tests/CI/pilot_newSchema.json
+++ b/tests/CI/pilot_newSchema.json
@@ -69,7 +69,15 @@
 			"VAR_JENKINS_QUEUE": {
 				"LocalCEType": "Pool/Singularity"
 			}
-		}
+		},
+		"jenkins-lhcb.cern.ch": {
+			"Site": "VAR_JENKINS_SITE",
+			"GridCEType": "LHCb"
+		},
+		"jenkins-lhcb-d.cern.ch": {
+			"Site": "VAR_JENKINS_SITE",
+			"GridCEType": "LHCbD"
+		  }	  
 	},
 	"GenericPilotDNs": [],
 	"Defaults": {
@@ -127,8 +135,32 @@
 					"ConfigureArchitecture",
 					"ConfigureCPURequirements",
 					"LaunchAgent"
+				],
+				"LHCb": [
+					"CheckWorkerNode",
+					"LHCbInstallDIRAC",
+					"LHCbConfigureBasics",
+					"RegisterPilot",
+					"CheckCECapabilities",
+					"LHCbAddCVMFSTags",
+					"CheckWNCapabilities",
+					"LHCbConfigureSite",
+					"LHCbConfigureArchitecture",
+					"LHCbConfigureCPURequirements"
+				],
+				"LHCbD": [
+					"CheckWorkerNode",
+					"InstallDIRAC",
+					"LHCbConfigureBasics",
+					"RegisterPilot",
+					"CheckCECapabilities",
+					"LHCbAddCVMFSTags",
+					"CheckWNCapabilities",
+					"LHCbConfigureSite",
+					"LHCbConfigureArchitecture",
+					"LHCbConfigureCPURequirements"
 				]
-			}
+		    }
 		}
 	},
 	"gridpp": {

--- a/tests/CI/pilot_oldSchema.json
+++ b/tests/CI/pilot_oldSchema.json
@@ -36,6 +36,18 @@
           "ConfigureArchitecture",
           "ConfigureCPURequirements",
           "LaunchAgent"
+        ],
+        "LHCb": [
+          "CheckWorkerNode",
+          "LHCbInstallDIRAC",
+          "LHCbConfigureBasics",
+          "RegisterPilot",
+          "CheckCECapabilities",
+          "LHCbAddCVMFSTags",
+          "CheckWNCapabilities",
+          "LHCbConfigureSite",
+          "LHCbConfigureArchitecture",
+          "LHCbConfigureCPURequirements"
         ]
       },
       "Logging": {
@@ -146,6 +158,10 @@
       "VAR_JENKINS_QUEUE": {
         "LocalCEType": "Pool/Singularity"
       }
+    },
+    "jenkins-lhcb.cern.ch": {
+      "Site": "VAR_JENKINS_SITE",
+      "GridCEType": "LHCb"
     }
   },
   "DefaultSetup": "DIRAC-Certification"

--- a/tests/CI/pilot_oldSchema.json
+++ b/tests/CI/pilot_oldSchema.json
@@ -48,6 +48,18 @@
           "LHCbConfigureSite",
           "LHCbConfigureArchitecture",
           "LHCbConfigureCPURequirements"
+        ],
+        "LHCbD": [
+          "CheckWorkerNode",
+          "InstallDIRAC",
+          "LHCbConfigureBasics",
+          "RegisterPilot",
+          "CheckCECapabilities",
+          "LHCbAddCVMFSTags",
+          "CheckWNCapabilities",
+          "LHCbConfigureSite",
+          "LHCbConfigureArchitecture",
+          "LHCbConfigureCPURequirements"
         ]
       },
       "Logging": {
@@ -162,6 +174,10 @@
     "jenkins-lhcb.cern.ch": {
       "Site": "VAR_JENKINS_SITE",
       "GridCEType": "LHCb"
+    },
+    "jenkins-lhcb-d.cern.ch": {
+      "Site": "VAR_JENKINS_SITE",
+      "GridCEType": "LHCbD"
     }
   },
   "DefaultSetup": "DIRAC-Certification"


### PR DESCRIPTION
This PR adds few integration test for the pilot:

1. The test simply installs the Pilot, getting configuration from lbcertifdirac70. The matrix variables are right now the python version (the version found on the WN) and the release version, for which here we take the `HEAD` of `rel-v8r0` and `integration` branches of DIRAC. More variables to this matrix can be added, if felt requested.
2. A test where DIRAC is sourced from CVMFS
3. A test for pilot that is installed and then tries to match a job (from lbcertifdirac70)
4. A test where DIRAC is sourced from CVMFS and tries to match a job
5. A integration test for the LHCb extension
6. A integration test for the LHCb extension, but using the vanilla Pilot DIRAC installer

These tests are only run on "push", so not in the pull requests (for a reason that I ignore, the base64 encoded certs used here are not properly passed in the environment of github actions runners for PRs). The tests ran on my fork: https://github.com/fstagni/Pilot/actions/workflows/integration.yml (after adding the correct secrets...).

The tests for LHCb are just an example. If you have your own Pilot extension, those specific tests can be added here: cc @sfayer @hmiyake @arrabito

