### PR TITLE
[devel] fix RemoteLogger activation logic; pilot logger timer fixes

### DIFF
--- a/Pilot/dirac-pilot.py
+++ b/Pilot/dirac-pilot.py
@@ -62,7 +62,8 @@ if __name__ == "__main__":
     # print the buffer, so we have a "classic' logger back in sync.
     sys.stdout.write(bufContent)
     # now the remote logger.
-    if pilotParams.pilotLogging:
+    remote = pilotParams.pilotLogging and (pilotParams.loggerURL is not None)
+    if remote:
         # In a remote logger enabled Dirac version we would have some classic logger content from a wrapper,
         # which we passed in:
         receivedContent = ""
@@ -97,7 +98,7 @@ if __name__ == "__main__":
 
     log.info("Executing commands: %s" % str(pilotParams.commands))
 
-    if pilotParams.pilotLogging:
+    if remote:
         # It's safer to cancel the timer here. Each command has got its own logger object with a timer cancelled by the
         # finaliser. No need for a timer in the "else" code segment below.
         try:
@@ -114,6 +115,6 @@ if __name__ == "__main__":
         else:
             log.error("Command %s could not be instantiated" % commandName)
             # send the last message and abandon ship.
-            if pilotParams.pilotLogging:
+            if remote:
                 log.buffer.flush()
             sys.exit(-1)

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -651,12 +651,13 @@ class CommandBase(object):
         """
 
         self.pp = pilotParams
-        isPilotLoggerOn = pilotParams.pilotLogging
         self.debugFlag = pilotParams.debugFlag
         loggerURL = pilotParams.loggerURL
+        # URL present and the flag is set:
+        isPilotLoggerOn = pilotParams.pilotLogging and (loggerURL is not None)
         interval = pilotParams.loggerTimerInterval
 
-        if loggerURL is None:
+        if not isPilotLoggerOn:
             self.log = Logger(self.__class__.__name__, debugFlag=self.debugFlag)
         else:
             # remote logger

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -1100,7 +1100,7 @@ class PilotParams(object):
             self.pilotLogging = pilotLogging.upper() == "TRUE"
         self.loggerURL = pilotOptions.get("RemoteLoggerURL")
         # logger buffer flush interval in seconds.
-        self.loggerTimerInterval = pilotOptions.get("RemoteLoggerTimerInterval", self.loggerTimerInterval)
+        self.loggerTimerInterval = int(pilotOptions.get("RemoteLoggerTimerInterval", self.loggerTimerInterval))
         pilotLogLevel = pilotOptions.get("PilotLogLevel", "INFO")
         if pilotLogLevel.lower() == "debug":
             self.debugFlag = True

--- a/Pilot/tests/Test_simplePilotLogger.py
+++ b/Pilot/tests/Test_simplePilotLogger.py
@@ -10,9 +10,9 @@ import sys
 import tempfile
 
 try:
-    from Pilot.pilotTools import CommandBase, PilotParams, RemoteLogger
+    from Pilot.pilotTools import CommandBase, PilotParams, Logger, RemoteLogger
 except ImportError:
-    from pilotTools import CommandBase, PilotParams, RemoteLogger
+    from pilotTools import CommandBase, PilotParams, Logger, RemoteLogger
 
 import unittest
 
@@ -122,6 +122,7 @@ class TestCommandBase(unittest.TestCase):
     @patch(("sys.argv"))
     @patch("subprocess.Popen")
     def test_executeAndGetOutput(self, popenMock, argvmock):
+
         argvmock.__getitem__.return_value = [
             "-d",
             "-g",
@@ -129,7 +130,9 @@ class TestCommandBase(unittest.TestCase):
             "-F",
             "tests/pilot.json",
         ]
-
+        import os
+        cwd = os.getcwd()
+        print("cwd", cwd)
         for size in [1000, 1024, 1025, 2005]:
             random_str = "".join(random.choice(string.ascii_letters + "\n") for i in range(size))
             if sys.version_info.major == 3:
@@ -144,14 +147,10 @@ class TestCommandBase(unittest.TestCase):
                 self.stderr_mock.write("Errare humanum est!")
             self.stderr_mock.seek(0)
             pp = PilotParams()
-            try:
-                cBase = CommandBase(pp)
-                # we have a logger URL set, so:
-                assert isinstance(cBase.log, RemoteLogger)
-            finally:
-                # and cancel the timer !
-                cBase.log.buffer.cancelTimer()
 
+            cBase = CommandBase(pp)
+
+            assert isinstance(cBase.log, Logger)
             popenMock.return_value.stdout = self.stdout_mock
             popenMock.return_value.stderr = self.stderr_mock
             outData = cBase.executeAndGetOutput("dummy")

--- a/Pilot/tests/Test_simplePilotLogger.py
+++ b/Pilot/tests/Test_simplePilotLogger.py
@@ -10,9 +10,9 @@ import sys
 import tempfile
 
 try:
-    from Pilot.pilotTools import CommandBase, PilotParams, Logger, RemoteLogger
+    from Pilot.pilotTools import CommandBase, PilotParams, Logger
 except ImportError:
-    from pilotTools import CommandBase, PilotParams, Logger, RemoteLogger
+    from pilotTools import CommandBase, PilotParams, Logger
 
 import unittest
 

--- a/Pilot/tests/Test_simplePilotLogger.py
+++ b/Pilot/tests/Test_simplePilotLogger.py
@@ -130,9 +130,7 @@ class TestCommandBase(unittest.TestCase):
             "-F",
             "tests/pilot.json",
         ]
-        import os
-        cwd = os.getcwd()
-        print("cwd", cwd)
+ 
         for size in [1000, 1024, 1025, 2005]:
             random_str = "".join(random.choice(string.ascii_letters + "\n") for i in range(size))
             if sys.version_info.major == 3:


### PR DESCRIPTION
Fix the logic when a remote logger is activated. There are 2 options in the CS:

- RemoteLoggerURL
- RemoteLogging flag

The remote logger is activated when the URL` is not None` and the flag is set to `True`.
The logic before was kinda broken, a disabled remote logger would not emit remote messages(OK) and it would act as a classic logger (OK) but caused problems when a timer was introduced and was not correctly canceled.