### PR TITLE
Guess location of CVMFS deployed installation

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -324,7 +324,7 @@ class InstallDIRAC(CommandBase):
             for CVMFS_location in self.pp.CVMFS_locations:
                 version = self.pp.releaseVersion or "pro"
                 arch = platform.system() + "-" + platform.machine()
-                preinstalledEnvScript = os.path.join(CVMFS_location, self.releaseProject.lower() + "dirac", version, arch, "diracosrc")
+                preinstalledEnvScript = os.path.join(CVMFS_location, self.pp.releaseProject.lower() + "dirac", version, arch, "diracosrc")
                 if os.path.isfile(preinstalledEnvScript):
                     break
 

--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -312,12 +312,21 @@ class InstallDIRAC(CommandBase):
 
         self.log.debug("self.pp.preinstalledEnv = %s" % self.pp.preinstalledEnv)
         self.log.debug("self.pp.preinstalledEnvPrefix = %s" % self.pp.preinstalledEnvPrefix)
+        self.log.debug("self.pp.CVMFS_locations = %s" % self.pp.CVMFS_locations)
         
         preinstalledEnvScript = self.pp.preinstalledEnv
         if not preinstalledEnvScript and self.pp.preinstalledEnvPrefix:
             version = self.pp.releaseVersion or "pro"
             arch = platform.system() + "-" + platform.machine()
             preinstalledEnvScript = os.path.join(self.pp.preinstalledEnvPrefix, version, arch, "diracosrc")
+
+        if not preinstalledEnvScript and self.pp.CVMFS_locations:
+            for CVMFS_location in self.pp.CVMFS_locations:
+                version = self.pp.releaseVersion or "pro"
+                arch = platform.system() + "-" + platform.machine()
+                preinstalledEnvScript = os.path.join(CVMFS_location, self.releaseProject.lower() + "dirac", version, arch, "diracosrc")
+                if os.path.isfile(preinstalledEnvScript):
+                    break
 
         self.log.debug("preinstalledEnvScript = %s" % preinstalledEnvScript)
 

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -930,6 +930,7 @@ class PilotParams(object):
             ("", "pilotUUID=", "pilot UUID"),
             ("", "preinstalledEnv=", "preinstalled pilot environment script location"),
             ("", "preinstalledEnvPrefix=", "preinstalled pilot environment area prefix"),
+            ("", "CVMFS_locations=", "comma-separated list of CVMS locations"),
         )
 
         # Possibly get Setup and JSON URL/filename from command line
@@ -1112,6 +1113,8 @@ class PilotParams(object):
                 self.preinstalledEnv = v
             elif o == "--preinstalledEnvPrefix":
                 self.preinstalledEnvPrefix = v
+            elif o == "--CVMFS_locations":
+                self.CVMFS_locations = v.split(",")
 
     def __loadJSON(self):
         """


### PR DESCRIPTION
This PR potentially makes it optional the specification of "preinstalledEnv" or "preinstalledEnvPrefix". 

If the deployment on CVMFS follows the "standard" setup of: `$location/{releaseProject}dirac/$version/$platorm/diracosrc` then adding `CVMFS_locations` list would be enough.


Loosely connected to https://github.com/DIRACGrid/DIRAC/pull/7359
