### PR TITLE
[devel] send a VO name with a log message (address issue #229

### DIFF
--- a/Pilot/dirac-pilot.py
+++ b/Pilot/dirac-pilot.py
@@ -70,7 +70,8 @@ if __name__ == "__main__":
         if not sys.stdin.isatty():
             receivedContent = sys.stdin.read()
         log = RemoteLogger(
-            pilotParams.loggerURL, "Pilot", bufsize=pilotParams.loggerBufsize, pilotUUID=pilotParams.pilotUUID, debugFlag=pilotParams.debugFlag
+            pilotParams.loggerURL, "Pilot", bufsize=pilotParams.loggerBufsize,
+            pilotUUID=pilotParams.pilotUUID, debugFlag=pilotParams.debugFlag, wnVO=pilotParams.wnVO,
         )
         log.info("Remote logger activated")
         log.buffer.write(receivedContent)


### PR DESCRIPTION
A pilot site changes requires to pass a VO name withing a `sendMessage` call to be used by a server if the name cannot be guessed form a client group. Requires a change in Dirac to accept the new method argument.