### PR TITLE
Define properly the pilot reference in the cloud case

### DIFF
--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -329,10 +329,10 @@ def getSubmitterInfo(ceName):
         flavour = "ARC"
         pilotReference = os.environ["GRID_GLOBAL_JOBURL"]
 
-    # VMDIRAC case
-    if "VMDIRAC_VERSION" in os.environ:
-        flavour = "VMDIRAC"
-        pilotReference = "vm://" + ceName + "/" + os.environ["JOB_ID"]
+    # Cloud case
+    if "PILOT_UUID" in os.environ:
+        flavour = "CLOUD"
+        pilotReference = os.environ["PILOT_UUID"]
 
     return flavour, pilotReference, {"Type": batchSystemType, "JobID": batchSystemJobID, "Parameters": batchSystemParameters}
 


### PR DESCRIPTION
Currently in the Cloud CE case the pilot reference is set to the pilot stamp while a "proper" reference is also defined.