### PR TITLE
fix: Removed malformed and unused cfg

### DIFF
--- a/tests/CI/PilotLoggerTest.cfg
+++ b/tests/CI/PilotLoggerTest.cfg
@@ -1,1 +1,0 @@
-{"cert_file": "certificates/client/cert.pem", "fileWithID": "PilotAgentUUID", "queuePath": "/queue/test", "host":"128.142.242.99", "ca_certs": "certificates/testca/cacert.pem", "key_file": "certificates/client/key.pem", "port":61614}


### PR DESCRIPTION
This file (`PilotLoggerTest.cfg`) is not used at all in the code, and furthermore is a malformed file.

See (this documentation)[https://github.com/DIRACGrid/diraccfg/] about cfg files.