### PR TITLE
hot-fix: Bad error handling on python2 directories

### DIFF
--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -82,7 +82,7 @@ except NameError:
 try:
     IsADirectoryError  # pylint: disable=used-before-assignment
 except NameError:
-    IsADirectoryError = OSError
+    IsADirectoryError = IOError
 
 # Timer 2.7 and < 3.3 versions issue where Timer is a function
 if sys.version_info.major == 2 or sys.version_info.major == 3 and sys.version_info.minor < 3:


### PR DESCRIPTION
Bad error handling on python2 caused this error (in current `devel` and `main` branch):

```bash
2025-04-01T15:17:45.220594Z INFO [Pilot] Remote logger activated
Traceback (most recent call last):
  File "../Pilot//Pilot/dirac-pilot.py", line 83, in <module>
    log.buffer.flush()
  File "/Pilot/Pilot/pilotTools.py", line 590, in wrapper
    return func(self, *args, **kwargs)
  File "/Pilot/Pilot/pilotTools.py", line 675, in flush
    self.senderFunc(buf)
  File "/Pilot/Pilot/pilotTools.py", line 710, in sendMessage
    context.load_cert_chain(cert)  # this is a proxy
IOError: [Errno 21] Is a directory
```

I think before we could use `OSError`, but not anymore. We need `IOError` cf error.

Env info: python2.7.15