### PR TITLE
Transform configure architecture command to avoid using `dirac-platform` command

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -121,6 +121,7 @@ jobs:
           - jenkins-mp.cern.ch
           - jenkins-mp-pool.cern.ch
           - jenkins-mp-pool-singularity.cern.ch
+          - jenkins-revised.cern.ch
 
     steps:
       - uses: actions/checkout@v4
@@ -266,6 +267,7 @@ jobs:
           - jenkins-mp-full.cern.ch
           - jenkins-mp-pool-full.cern.ch
           - jenkins-mp-pool-singularity-full.cern.ch
+          - jenkins-revised.cern.ch
 
     steps:
       - uses: actions/checkout@v4

--- a/Pilot/pilotTools.py
+++ b/Pilot/pilotTools.py
@@ -832,7 +832,7 @@ class CommandBase(object):
 
         self.log.info("List of child processes of current PID:")
         retCode, _outData = self.executeAndGetOutput(
-            "ps --forest -o pid,%%cpu,%%mem,tty,stat,time,cmd --ppid %d" % os.getpid()
+            "ps --forest -o pid,%%cpu,%%mem,tty,stat,time,cmd -g %d" % os.getpid()
         )
         if retCode:
             self.log.error("Failed to issue ps [ERROR %d] " % retCode)

--- a/tests/CI/pilot_newSchema.json
+++ b/tests/CI/pilot_newSchema.json
@@ -81,7 +81,11 @@
 		"jenkins-lhcb-dd.cern.ch": {
 			"Site": "VAR_JENKINS_SITE",
 			"GridCEType": "LHCbDD"
-		}	  
+		},
+    "jenkins-revised.cern.ch": {
+			"Site": "VAR_JENKINS_SITE",
+			"GridCEType": "TEST-REVISED-COMMANDS"
+    }
 	},
 	"Defaults": {
 		"Pilot": {
@@ -92,8 +96,9 @@
 				"TEST-FULL": "CheckWorkerNode, InstallDIRAC, ConfigureBasics, RegisterPilot, CheckCECapabilities, CheckWNCapabilities, ConfigureSite, ConfigureArchitecture, ConfigureCPURequirements, LaunchAgent",
 				"LHCb": "CheckWorkerNode, LHCbInstallDIRAC, LHCbConfigureBasics, RegisterPilot, CheckCECapabilities, LHCbAddCVMFSTags, CheckWNCapabilities, ConfigureSite, LHCbConfigureArchitecture, ConfigureCPURequirements",
 				"LHCbD": "CheckWorkerNode, InstallDIRAC, LHCbConfigureBasics, RegisterPilot, CheckCECapabilities, LHCbAddCVMFSTags, CheckWNCapabilities, ConfigureSite, LHCbConfigureArchitecture, ConfigureCPURequirements",
-				"LHCbDD": "CheckWorkerNode, InstallDIRAC, ConfigureBasics, RegisterPilot, CheckCECapabilities, LHCbAddCVMFSTags, CheckWNCapabilities, ConfigureSite, LHCbConfigureArchitecture, ConfigureCPURequirements"
-		    }
+				"LHCbDD": "CheckWorkerNode, InstallDIRAC, ConfigureBasics, RegisterPilot, CheckCECapabilities, LHCbAddCVMFSTags, CheckWNCapabilities, ConfigureSite, LHCbConfigureArchitecture, ConfigureCPURequirements",
+				"TEST-REVISED-COMMANDS": "CheckWorkerNode, InstallDIRAC, ConfigureBasics, RegisterPilot, CheckCECapabilities, CheckWNCapabilities, ConfigureSite, ConfigureArchitectureWithoutCLI, ConfigureCPURequirements"
+      }
 		}
 	},
 	"gridpp": {


### PR DESCRIPTION
Move from [DIRAC's `dirac-platform` command](https://github.com/DIRACGrid/DIRAC/blob/integration/src/DIRAC/Core/scripts/dirac_platform.py).