### PR TITLE
fix: use PEP 440 direct URL syntax instead of deprecated #egg= fragment

### DIFF
--- a/Pilot/pilotCommands.py
+++ b/Pilot/pilotCommands.py
@@ -348,15 +348,12 @@ class InstallDIRAC(CommandBase):
                     url, project, branch = elements
                 elif len(elements) == 1:
                     url = elements[0]
-                if url.endswith(".git"):
-                    pipInstalling += "git+"
-                pipInstalling += url
+                gitUrl = "git+" + url if url.endswith(".git") else url
                 if branch and project:
-                    # e.g. git+https://github.com/fstagni/DIRAC.git@v7r2-fixes33#egg=DIRAC[pilot]
-                    pipInstalling += "@%s#egg=%s" % (branch, project)
-                pipInstalling += "[pilot]"
-
-                # pipInstalling = "pip install %s%s@%s#egg=%s[pilot]" % (prefix, url, branch, project)
+                    # e.g. DIRAC[pilot] @ git+https://github.com/fstagni/DIRAC.git@v7r2-fixes33
+                    pipInstalling += "'%s[pilot] @ %s@%s'" % (project, gitUrl, branch)
+                else:
+                    pipInstalling += "%s[pilot]" % gitUrl
                 retCode, output = self.executeAndGetOutput(pipInstalling, self.pp.installEnv)
                 if retCode:
                     self.log.error("Could not %s [ERROR %d]" % (pipInstalling, retCode))


### PR DESCRIPTION
## Summary

- Replace deprecated `#egg=` fragment syntax with PEP 440 direct URL syntax (`name[extra] @ URL`) in `pilotCommands.py`
- Fixes pip install failures when using `--modules` with pip >= 25.0, which rejects `#egg=` fragments with `error: invalid-egg-fragment`

## Motivation

Since pip 25.0 (January 2025), the `#egg=` URL fragment is no longer accepted and raises an `invalid-egg-fragment` error:

```
× The 'DIRAC[pilot]' egg fragment is invalid
╰─> from 'git+https://github.com/ryuwd/DIRAC.git@feat/cwl-job-submission#egg=DIRAC[pilot]'

hint: Try using the Direct URL requirement syntax: 'name[extra] @ URL'
```

This breaks any pilot installation using the `modules` option (e.g. `url:::project:::branch` syntax) to install a non-released DIRAC version from a git repository.

## Changes

```
# Before
pip install git+https://github.com/fstagni/DIRAC.git@v7r2-fixes33#egg=DIRAC[pilot]

# After
pip install DIRAC[pilot] @ git+https://github.com/fstagni/DIRAC.git@v7r2-fixes33
```
