### PR TITLE
Increase artifact retention time a little

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,4 +47,4 @@ jobs:
         with:
           name: Pilot_${{ matrix.branch }}
           path: tmp_dir
-          retention-days: 1
+          retention-days: 3


### PR DESCRIPTION
Hi,

It seems like there is no leeway in the nightly builds: They run every day with a retention period of 1 day, so if the build is delayed[*] then things will break in the DIRAC module tests immediately. I propose increasing this to 3 days (I'm assuming this will fit wherever these are stored)...

Regards,
Simon

[*] You're probably already working on this, but it appears the Pilot repo has been inactive for 60 days, so the actions have been disabled and will need re-enabling... This means today's nightly build didn't get scheduled which is the cause of (some of!) the test failures on the DIRAC repo CI.
